### PR TITLE
Pass service name as part of Downstream instruction

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 
 script:
   - make test_ci
-  - travis_retry goveralls -coverprofile=cover.out -service=travis-ci
+  - travis_retry goveralls -coverprofile=cover.out -service=travis-ci || true
   - make crossdock
   - timeout 5 docker-compose -f crossdock/docker-compose.yml logs || true
 

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ idl-submodule:
 	git submodule update
 
 thrift-image:
-	docker pull $(THRIFT_IMG)
 	$(THRIFT) -version
 
 .PHONY: install_ci

--- a/crossdock/client/client.go
+++ b/crossdock/client/client.go
@@ -36,6 +36,7 @@ type Client struct {
 	ServerPortHTTP     string
 	ServerPortTChannel string
 	listener           net.Listener
+	hostMapper         func(service string) string
 }
 
 // Start begins a blocking Crossdock client
@@ -107,6 +108,14 @@ func (c *Client) dispatch(s behavior.Sink, ps behavior.Params) {
 	default:
 		behavior.Skipf(s, "unknown behavior %q", v)
 	}
+}
+
+func (c *Client) mapServiceToHost(service string) string {
+	mapper := c.hostMapper
+	if mapper == nil {
+		return service
+	}
+	return mapper(service)
 }
 
 // httpParams provides access to behavior parameters that are stored inside an

--- a/crossdock/client/trace.go
+++ b/crossdock/client/trace.go
@@ -42,20 +42,23 @@ func (c *Client) trace(s behavior.Sink, ps behavior.Params) {
 	server1 := ps.Param(server1NameParam)
 
 	level2 := tracetest.NewDownstream()
-	level2.Host = ps.Param(server2NameParam)
+	level2.ServiceName = ps.Param(server2NameParam)
+	level2.Host = c.mapServiceToHost(level2.ServiceName)
 	level2.Port = c.transport2port(ps.Param(server2TransportParam))
 	level2.Transport = transport2transport(ps.Param(server2TransportParam))
 	level2.ClientType = ps.Param(server2ClientParam)
 	level1.Downstream = level2
 
 	level3 := tracetest.NewDownstream()
-	level3.Host = ps.Param(server3NameParam)
+	level3.ServiceName = ps.Param(server3NameParam)
+	level3.Host = c.mapServiceToHost(level3.ServiceName)
 	level3.Port = c.transport2port(ps.Param(server3TransportParam))
 	level3.Transport = transport2transport(ps.Param(server3TransportParam))
 	level3.ClientType = ps.Param(server3ClientParam)
 	level2.Downstream = level3
 
-	url := fmt.Sprintf("http://%s:%s/start_trace", server1, c.ServerPortHTTP)
+	server1host := c.mapServiceToHost(server1)
+	url := fmt.Sprintf("http://%s:%s/start_trace", server1host, c.ServerPortHTTP)
 	resp, err := common.PostJSON(context.Background(), url, level1)
 	if err != nil {
 		behavior.Errorf(s, err.Error())

--- a/crossdock/common/constants.go
+++ b/crossdock/common/constants.go
@@ -29,4 +29,7 @@ const (
 
 	// DefaultServerPortTChannel is the port where TChannel server runs
 	DefaultServerPortTChannel = "8082"
+
+	// DefaultServiceName is the service name used by TChannel server
+	DefaultServiceName = "go"
 )

--- a/crossdock/rules.mk
+++ b/crossdock/rules.mk
@@ -9,7 +9,8 @@ crossdock: crossdock-linux-bin
 	docker-compose -f $(XDOCK_YAML) kill go
 	docker-compose -f $(XDOCK_YAML) rm -f go
 	docker-compose -f $(XDOCK_YAML) build go
-	docker-compose -f $(XDOCK_YAML) run crossdock
+	docker-compose -f $(XDOCK_YAML) run crossdock 2>&1 | tee run-crossdock.log
+	grep 'Tests passed!' run-crossdock.log
 
 
 .PHONY: crossdock-fresh
@@ -20,3 +21,6 @@ crossdock-fresh: crossdock-linux-bin
 	docker-compose -f $(XDOCK_YAML) build
 	docker-compose -f $(XDOCK_YAML) run crossdock
 
+.PHONE: crossdock-logs
+crossdock-logs:
+	docker-compose -f $(XDOCK_YAML) logs

--- a/crossdock/server/server.go
+++ b/crossdock/server/server.go
@@ -52,6 +52,9 @@ func (s *Server) Start() error {
 	if s.HostPortHTTP == "" {
 		s.HostPortHTTP = ":" + common.DefaultServerPortHTTP
 	}
+	if s.HostPortTChannel == "" {
+		s.HostPortTChannel = ":" + common.DefaultServerPortTChannel
+	}
 
 	if err := s.startTChannelServer(); err != nil {
 		return err

--- a/crossdock/server/server_test.go
+++ b/crossdock/server/server_test.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/crossdock/common"
 	"github.com/uber/jaeger-client-go/crossdock/thrift/tracetest"
-
-	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 func TestServerJSON(t *testing.T) {
@@ -28,13 +28,15 @@ func TestServerJSON(t *testing.T) {
 	req.Sampled = true
 	req.Baggage = "Zoidberg"
 	req.Downstream = &tracetest.Downstream{
-		Host:      "localhost",
-		Port:      s.GetPortHTTP(),
-		Transport: tracetest.Transport_HTTP,
+		ServiceName: "go",
+		Host:        "localhost",
+		Port:        s.GetPortHTTP(),
+		Transport:   tracetest.Transport_HTTP,
 		Downstream: &tracetest.Downstream{
-			Host:      "localhost",
-			Port:      s.GetPortTChannel(),
-			Transport: tracetest.Transport_TCHANNEL,
+			ServiceName: "go",
+			Host:        "localhost",
+			Port:        s.GetPortTChannel(),
+			Transport:   tracetest.Transport_TCHANNEL,
 		},
 	}
 

--- a/crossdock/server/trace.go
+++ b/crossdock/server/trace.go
@@ -23,13 +23,13 @@ package server
 import (
 	"fmt"
 
-	"github.com/uber/jaeger-client-go"
-	"github.com/uber/jaeger-client-go/crossdock/common"
-	"github.com/uber/jaeger-client-go/crossdock/thrift/tracetest"
-
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 	"golang.org/x/net/context"
+
+	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/crossdock/common"
+	"github.com/uber/jaeger-client-go/crossdock/thrift/tracetest"
 )
 
 func (s *Server) doStartTrace(req *tracetest.StartTraceRequest) (*tracetest.TraceResponse, error) {
@@ -83,7 +83,7 @@ func (s *Server) callDownstream(ctx context.Context, downstream *tracetest.Downs
 func (s *Server) callDownstreamHTTP(ctx context.Context, downstream *tracetest.Downstream) (*tracetest.TraceResponse, error) {
 	req := &tracetest.JoinTraceRequest{Downstream: downstream.Downstream}
 	url := fmt.Sprintf("http://%s:%s/join_trace", downstream.Host, downstream.Port)
-	println("Calling downstream at", url)
+	fmt.Printf("Calling downstream service '%s' at %s\n", downstream.ServiceName, url)
 	return common.PostJSON(ctx, url, req)
 }
 

--- a/crossdock/thrift/tracetest.thrift
+++ b/crossdock/thrift/tracetest.thrift
@@ -3,11 +3,12 @@ namespace java com.uber.jaeger.crossdock.tracetest
 enum Transport { HTTP, TCHANNEL }
 
 struct Downstream {
-    1: required string host
-    2: required string port
-    3: required Transport transport
-    4: required string clientType
-    5: optional Downstream downstream
+    1: required string serviceName
+    2: required string host
+    3: required string port
+    4: required Transport transport
+    5: required string clientType
+    6: optional Downstream downstream
 }
 
 struct StartTraceRequest {

--- a/crossdock/thrift/tracetest/ttypes.go
+++ b/crossdock/thrift/tracetest/ttypes.go
@@ -59,21 +59,27 @@ func (p *Transport) UnmarshalText(text []byte) error {
 }
 
 // Attributes:
+//  - ServiceName
 //  - Host
 //  - Port
 //  - Transport
 //  - ClientType
 //  - Downstream
 type Downstream struct {
-	Host       string      `thrift:"host,1,required" json:"host"`
-	Port       string      `thrift:"port,2,required" json:"port"`
-	Transport  Transport   `thrift:"transport,3,required" json:"transport"`
-	ClientType string      `thrift:"clientType,4,required" json:"clientType"`
-	Downstream *Downstream `thrift:"downstream,5" json:"downstream,omitempty"`
+	ServiceName string      `thrift:"serviceName,1,required" json:"serviceName"`
+	Host        string      `thrift:"host,2,required" json:"host"`
+	Port        string      `thrift:"port,3,required" json:"port"`
+	Transport   Transport   `thrift:"transport,4,required" json:"transport"`
+	ClientType  string      `thrift:"clientType,5,required" json:"clientType"`
+	Downstream  *Downstream `thrift:"downstream,6" json:"downstream,omitempty"`
 }
 
 func NewDownstream() *Downstream {
 	return &Downstream{}
+}
+
+func (p *Downstream) GetServiceName() string {
+	return p.ServiceName
 }
 
 func (p *Downstream) GetHost() string {
@@ -109,6 +115,7 @@ func (p *Downstream) Read(iprot thrift.TProtocol) error {
 		return thrift.PrependError(fmt.Sprintf("%T read error: ", p), err)
 	}
 
+	var issetServiceName bool = false
 	var issetHost bool = false
 	var issetPort bool = false
 	var issetTransport bool = false
@@ -127,24 +134,29 @@ func (p *Downstream) Read(iprot thrift.TProtocol) error {
 			if err := p.readField1(iprot); err != nil {
 				return err
 			}
-			issetHost = true
+			issetServiceName = true
 		case 2:
 			if err := p.readField2(iprot); err != nil {
 				return err
 			}
-			issetPort = true
+			issetHost = true
 		case 3:
 			if err := p.readField3(iprot); err != nil {
 				return err
 			}
-			issetTransport = true
+			issetPort = true
 		case 4:
 			if err := p.readField4(iprot); err != nil {
 				return err
 			}
-			issetClientType = true
+			issetTransport = true
 		case 5:
 			if err := p.readField5(iprot); err != nil {
+				return err
+			}
+			issetClientType = true
+		case 6:
+			if err := p.readField6(iprot); err != nil {
 				return err
 			}
 		default:
@@ -158,6 +170,9 @@ func (p *Downstream) Read(iprot thrift.TProtocol) error {
 	}
 	if err := iprot.ReadStructEnd(); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T read struct end error: ", p), err)
+	}
+	if !issetServiceName {
+		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field ServiceName is not set"))
 	}
 	if !issetHost {
 		return thrift.NewTProtocolExceptionWithType(thrift.INVALID_DATA, fmt.Errorf("Required field Host is not set"))
@@ -178,7 +193,7 @@ func (p *Downstream) readField1(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 1: ", err)
 	} else {
-		p.Host = v
+		p.ServiceName = v
 	}
 	return nil
 }
@@ -187,14 +202,23 @@ func (p *Downstream) readField2(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 2: ", err)
 	} else {
-		p.Port = v
+		p.Host = v
 	}
 	return nil
 }
 
 func (p *Downstream) readField3(iprot thrift.TProtocol) error {
-	if v, err := iprot.ReadI32(); err != nil {
+	if v, err := iprot.ReadString(); err != nil {
 		return thrift.PrependError("error reading field 3: ", err)
+	} else {
+		p.Port = v
+	}
+	return nil
+}
+
+func (p *Downstream) readField4(iprot thrift.TProtocol) error {
+	if v, err := iprot.ReadI32(); err != nil {
+		return thrift.PrependError("error reading field 4: ", err)
 	} else {
 		temp := Transport(v)
 		p.Transport = temp
@@ -202,16 +226,16 @@ func (p *Downstream) readField3(iprot thrift.TProtocol) error {
 	return nil
 }
 
-func (p *Downstream) readField4(iprot thrift.TProtocol) error {
+func (p *Downstream) readField5(iprot thrift.TProtocol) error {
 	if v, err := iprot.ReadString(); err != nil {
-		return thrift.PrependError("error reading field 4: ", err)
+		return thrift.PrependError("error reading field 5: ", err)
 	} else {
 		p.ClientType = v
 	}
 	return nil
 }
 
-func (p *Downstream) readField5(iprot thrift.TProtocol) error {
+func (p *Downstream) readField6(iprot thrift.TProtocol) error {
 	p.Downstream = &Downstream{}
 	if err := p.Downstream.Read(iprot); err != nil {
 		return thrift.PrependError(fmt.Sprintf("%T error reading struct: ", p.Downstream), err)
@@ -238,6 +262,9 @@ func (p *Downstream) Write(oprot thrift.TProtocol) error {
 	if err := p.writeField5(oprot); err != nil {
 		return err
 	}
+	if err := p.writeField6(oprot); err != nil {
+		return err
+	}
 	if err := oprot.WriteFieldStop(); err != nil {
 		return thrift.PrependError("write field stop error: ", err)
 	}
@@ -248,67 +275,80 @@ func (p *Downstream) Write(oprot thrift.TProtocol) error {
 }
 
 func (p *Downstream) writeField1(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("host", thrift.STRING, 1); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:host: ", p), err)
+	if err := oprot.WriteFieldBegin("serviceName", thrift.STRING, 1); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 1:serviceName: ", p), err)
 	}
-	if err := oprot.WriteString(string(p.Host)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.host (1) field write error: ", p), err)
+	if err := oprot.WriteString(string(p.ServiceName)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.serviceName (1) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:host: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 1:serviceName: ", p), err)
 	}
 	return err
 }
 
 func (p *Downstream) writeField2(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("port", thrift.STRING, 2); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:port: ", p), err)
+	if err := oprot.WriteFieldBegin("host", thrift.STRING, 2); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 2:host: ", p), err)
 	}
-	if err := oprot.WriteString(string(p.Port)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.port (2) field write error: ", p), err)
+	if err := oprot.WriteString(string(p.Host)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.host (2) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:port: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 2:host: ", p), err)
 	}
 	return err
 }
 
 func (p *Downstream) writeField3(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("transport", thrift.I32, 3); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:transport: ", p), err)
+	if err := oprot.WriteFieldBegin("port", thrift.STRING, 3); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 3:port: ", p), err)
 	}
-	if err := oprot.WriteI32(int32(p.Transport)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.transport (3) field write error: ", p), err)
+	if err := oprot.WriteString(string(p.Port)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.port (3) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:transport: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 3:port: ", p), err)
 	}
 	return err
 }
 
 func (p *Downstream) writeField4(oprot thrift.TProtocol) (err error) {
-	if err := oprot.WriteFieldBegin("clientType", thrift.STRING, 4); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:clientType: ", p), err)
+	if err := oprot.WriteFieldBegin("transport", thrift.I32, 4); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 4:transport: ", p), err)
 	}
-	if err := oprot.WriteString(string(p.ClientType)); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T.clientType (4) field write error: ", p), err)
+	if err := oprot.WriteI32(int32(p.Transport)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.transport (4) field write error: ", p), err)
 	}
 	if err := oprot.WriteFieldEnd(); err != nil {
-		return thrift.PrependError(fmt.Sprintf("%T write field end error 4:clientType: ", p), err)
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 4:transport: ", p), err)
 	}
 	return err
 }
 
 func (p *Downstream) writeField5(oprot thrift.TProtocol) (err error) {
+	if err := oprot.WriteFieldBegin("clientType", thrift.STRING, 5); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:clientType: ", p), err)
+	}
+	if err := oprot.WriteString(string(p.ClientType)); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T.clientType (5) field write error: ", p), err)
+	}
+	if err := oprot.WriteFieldEnd(); err != nil {
+		return thrift.PrependError(fmt.Sprintf("%T write field end error 5:clientType: ", p), err)
+	}
+	return err
+}
+
+func (p *Downstream) writeField6(oprot thrift.TProtocol) (err error) {
 	if p.IsSetDownstream() {
-		if err := oprot.WriteFieldBegin("downstream", thrift.STRUCT, 5); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field begin error 5:downstream: ", p), err)
+		if err := oprot.WriteFieldBegin("downstream", thrift.STRUCT, 6); err != nil {
+			return thrift.PrependError(fmt.Sprintf("%T write field begin error 6:downstream: ", p), err)
 		}
 		if err := p.Downstream.Write(oprot); err != nil {
 			return thrift.PrependError(fmt.Sprintf("%T error writing struct: ", p.Downstream), err)
 		}
 		if err := oprot.WriteFieldEnd(); err != nil {
-			return thrift.PrependError(fmt.Sprintf("%T write field end error 5:downstream: ", p), err)
+			return thrift.PrependError(fmt.Sprintf("%T write field end error 6:downstream: ", p), err)
 		}
 	}
 	return err


### PR DESCRIPTION
The tchannel service name was incorrectly hardcoded to "go".
This was creating false positives in Java crossdock tests,
since Java client does not yet support TChannel, but the
tests were succeeding because Go service was always called.