### PR TITLE
Fix README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ func main() {
 
     tracer, closer, err := cfg.Tracing.New("your-service-name", nil)
     // check err
-    defer closer()
+    defer closer.Close()
 
     opentracing.InitGlobalTracer(tracer)
     ...


### PR DESCRIPTION
`cfg.Tracing.New` returns an `io.Closer` interface, not the `Close` function itself.