### PR TITLE
Check childOf reference for non-empty context before using as parent

### DIFF
--- a/context.go
+++ b/context.go
@@ -86,6 +86,11 @@ func (c SpanContext) IsDebug() bool {
 	return (c.flags & flagDebug) == flagDebug
 }
 
+// IsValid indicates whether this context actually represents a valid trace.
+func (c SpanContext) IsValid() bool {
+	return c.traceID != 0 && c.spanID != 0
+}
+
 func (c SpanContext) String() string {
 	return fmt.Sprintf("%x:%x:%x:%x", c.traceID, c.spanID, c.parentID, c.flags)
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 8a19424b98ca02a54b68a116e0759a9c982576f7a02fd50935c2c41673fe7895
-updated: 2016-09-11T20:47:02.017923936-04:00
+updated: 2016-09-20T19:11:52.366084254-04:00
 imports:
 - name: github.com/apache/thrift
   version: 23d6746079d7b5fdb38214387c63f987e68a6d8f
@@ -31,7 +31,7 @@ imports:
 - name: github.com/uber-go/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: github.com/uber/tchannel-go
-  version: 1a0e35378f6f721bc07f6c4466bc9701ed70b506
+  version: f57e644626dbf4d87ee2b36571600c21f8255f1f
   subpackages:
   - atomic
   - relay

--- a/tracer.go
+++ b/tracer.go
@@ -155,9 +155,11 @@ func (t *tracer) startSpanWithOptions(
 	for _, ref := range options.References {
 		if ref.Type == opentracing.ChildOfRef {
 			if p, ok := ref.ReferencedContext.(SpanContext); ok {
-				parent = p
-				hasParent = true
-				break
+				if p.IsValid() || p.isDebugIDContainerOnly() {
+					parent = p
+					hasParent = true
+					break
+				}
 			} else {
 				t.logger.Error(fmt.Sprintf(
 					"ChildOf reference contains invalid type of SpanReference: %s",

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -229,9 +229,10 @@ func TestEmptySpanContextAsParent(t *testing.T) {
 	tracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter())
 	defer tc.Close()
 
-	ctx := emptyContext
-	span := tracer.StartSpan("test", opentracing.ChildOf(ctx))
-	assert.NotEqual(t, uint64(0), uint64(span.Context().(SpanContext).traceID))
+	span := tracer.StartSpan("test", opentracing.ChildOf(emptyContext))
+	ctx := span.Context().(SpanContext)
+	assert.NotEqual(t, uint64(0), uint64(ctx.traceID))
+	assert.True(t, ctx.IsValid())
 }
 
 type dummyPropagator struct{}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -225,6 +225,15 @@ func TestInjectorExtractorOptions(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestEmptySpanContextAsParent(t *testing.T) {
+	tracer, tc := NewTracer("x", NewConstSampler(true), NewNullReporter())
+	defer tc.Close()
+
+	ctx := emptyContext
+	span := tracer.StartSpan("test", opentracing.ChildOf(ctx))
+	assert.NotEqual(t, uint64(0), uint64(span.Context().(SpanContext).traceID))
+}
+
 type dummyPropagator struct{}
 type dummyCarrier struct {
 	ok bool


### PR DESCRIPTION
When requests were coming from old tchannel, the Zipkin codec would
return `emptyContext, opentracing.ErrSpanContextNotFound`, but that
empty context was then passed to `ChildOf()` and treated as a real
parent reference, resulting in a new trace like `0:6ca9d0ce0d287:0:0`.