### PR TITLE
Remove call to Github API to get current branch name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ after_failure:
 
 after_success:
   - export REPO=jaegertracing/xdock-go
-  - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
-  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
   - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS


### PR DESCRIPTION
Now that Travis has shipped travis-ci/travis-ci#1633, we don't need to make a call to the Github API to get the current branch name from both PUSH and PR builds.