### PR TITLE
Add a jaeger-baggage header for easier baggage passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes by Version
 ==================
 
+1.5.2 (unreleased)
+-------------------
+
+- Add the jaeger-debug header
+
 1.5.1 (2016-09-27)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,25 @@ are available:
      sampling rate.
   1. `RateLimitingSampler` can be used to allow only a certain fixed
      number of traces to be sampled per second.
+     
+### Baggage Injection
 
+The OpenTracing spec allows for [baggage](http://opentracing.io/spec/#baggage),
+which are key value pairs that are added to the span context and propagated
+throughout the trace.
+An external process can inject baggage by setting the special 
+HTTP Header `jaeger-baggage` on a request
+
+```sh
+curl -H "jaeger-baggage: key1=value1, key2=value2" http://myhost.com
+```
+
+Baggage can also be programatically set inside your service by doing
+the following
+
+```go
+span.SetBaggageItem("key", "value")
+```
 
 ### Debug Traces (Forced Sampling)
 

--- a/constants.go
+++ b/constants.go
@@ -33,6 +33,11 @@ const (
 	// trace can be found in the UI using this value as a correlation ID.
 	JaegerDebugHeader = "jaeger-debug-id"
 
+	// JaegerBaggageHeader is the name of the HTTP header that is used to submit baggage.
+	// It differs from TraceBaggageHeaderPrefix in that it can be used only in cases where
+	// a root span does not exist.
+	JaegerBaggageHeader = "jaeger-baggage"
+
 	// TracerHostnameTagKey used to report host name of the process.
 	TracerHostnameTagKey = "jaeger.hostname"
 

--- a/tracer.go
+++ b/tracer.go
@@ -160,7 +160,7 @@ func (t *tracer) startSpanWithOptions(
 	for _, ref := range options.References {
 		if ref.Type == opentracing.ChildOfRef {
 			if p, ok := ref.ReferencedContext.(SpanContext); ok {
-				if p.IsValid() || p.isDebugIDContainerOnly() {
+				if p.IsValid() || p.isDebugIDContainerOnly() || len(p.baggage) != 0 {
 					parent = p
 					hasParent = true
 					break


### PR DESCRIPTION
Making a request with a `jaeger-baggage` request creates a
root span even without a trace.

See https://github.com/uber/jaeger-client-go/issues/45