### PR TITLE
Add adaptive sampler

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -68,4 +68,8 @@ const (
 	// SamplerTypeRateLimiting is the type of sampler that samples
 	// only up to a fixed number of traces per second.
 	SamplerTypeRateLimiting = "ratelimiting"
+
+	// SamplerTypeLowerBound is the type of sampler that samples
+	// only up to a fixed number of traces per second.
+	SamplerTypeLowerBound = "lowerbound"
 )

--- a/sampler.go
+++ b/sampler.go
@@ -245,7 +245,8 @@ func (s *adaptiveSampler) Close() {
 
 func (s *adaptiveSampler) Equal(other Sampler) bool {
 	if o, ok := other.(*adaptiveSampler); ok {
-		if !mapKeysEqual(s.probabilisticSamplers, o.probabilisticSamplers) {
+		if !mapKeysEqual(s.probabilisticSamplers, o.probabilisticSamplers) ||
+			!mapKeysEqual(s.rateLimitingSamplers, o.rateLimitingSamplers) {
 			return false
 		}
 		for operation, sampler := range s.probabilisticSamplers {

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/uber/jaeger-client-go/utils"
 )
 
+var (
+	testOperationName = "op"
+)
+
 func TestSamplerTags(t *testing.T) {
 	prob, err := NewProbabilisticSampler(0.1)
 	require.NoError(t, err)
@@ -33,7 +37,7 @@ func TestSamplerTags(t *testing.T) {
 		{remote, "const", true},
 	}
 	for _, test := range tests {
-		tags := test.sampler.getTags()
+		tags := test.sampler.getTags(testOperationName)
 		count := 0
 		for _, tag := range tags {
 			if tag.key == SamplerTypeTagKey {
@@ -59,8 +63,8 @@ func TestProbabilisticSamplerErrors(t *testing.T) {
 func TestProbabilisticSampler(t *testing.T) {
 	sampler, _ := NewProbabilisticSampler(0.5)
 	id1 := uint64(1) << 62
-	assert.False(t, sampler.IsSampled(id1+10))
-	assert.True(t, sampler.IsSampled(id1-20))
+	assert.False(t, sampler.IsSampled(id1+10, testOperationName))
+	assert.True(t, sampler.IsSampled(id1-20, testOperationName))
 	sampler2, _ := NewProbabilisticSampler(0.5)
 	assert.True(t, sampler.Equal(sampler2))
 	assert.False(t, sampler.Equal(NewConstSampler(true)))
@@ -73,7 +77,7 @@ func TestProbabilisticSamplerPerformance(t *testing.T) {
 	var count uint64
 	for i := 0; i < 100000000; i++ {
 		id := uint64(rand.Int63())
-		if sampler.IsSampled(id) {
+		if sampler.IsSampled(id, testOperationName) {
 			count++
 		}
 	}
@@ -134,8 +138,8 @@ func TestRemotelyControlledSampler(t *testing.T) {
 	assert.NotEqual(t, initSampler, sampler.sampler, "Sampler should have been updated")
 
 	id := uint64(1) << 62
-	assert.True(t, sampler.IsSampled(id-10))
-	assert.False(t, sampler.IsSampled(id+10))
+	assert.True(t, sampler.IsSampled(id-10, testOperationName))
+	assert.False(t, sampler.IsSampled(id+10, testOperationName))
 
 	sampler.sampler = initSampler
 	c := make(chan time.Time)

--- a/span.go
+++ b/span.go
@@ -68,13 +68,14 @@ type span struct {
 	}
 
 	// tags attached to this span
-	tags []tag
+	tags []Tag
 
 	// The span's "micro-log"
 	logs []opentracing.LogRecord
 }
 
-type tag struct {
+// Tag a simple key value wrapper
+type Tag struct {
 	key   string
 	value interface{}
 }
@@ -108,11 +109,11 @@ func (s *span) setTagNoLocking(key string, value interface{}) {
 		handled = handler(s, key, value)
 	}
 	if !handled {
-		s.tags = append(s.tags, tag{key: key, value: value})
+		s.tags = append(s.tags, Tag{key: key, value: value})
 	}
 }
 
-func (s *span) setTracerTags(tags []tag) {
+func (s *span) setTracerTags(tags []Tag) {
 	s.Lock()
 	for _, tag := range tags {
 		s.tags = append(s.tags, tag)

--- a/tracer.go
+++ b/tracer.go
@@ -192,10 +192,10 @@ func (t *tracer) startSpanWithOptions(
 		if hasParent && parent.isDebugIDContainerOnly() {
 			ctx.flags |= (flagSampled | flagDebug)
 			samplerTags = []tag{{key: JaegerDebugHeader, value: parent.debugID}}
-		} else if t.sampler.IsSampled(ctx.traceID) {
+		} else if t.sampler.IsSampled(ctx.traceID, operationName) {
 			ctx.flags |= flagSampled
 			// this currently assumes that sampler tags are stable
-			samplerTags = t.sampler.getTags()
+			samplerTags = t.sampler.getTags(operationName)
 		}
 	} else {
 		ctx.traceID = parent.traceID


### PR DESCRIPTION
- [x] Add tests

This is a first crack at adding an adaptive sampler to the go client.

I feel like I've somewhat polluted the Sampler interface since only the adaptiveSampler is actually using the newly passed in operation string.

The other way I could do this is rather than having the adaptiveSampler keeping track of multiple samplers, the ProbabilitySampler and RateLimitSampler could keep track of multiple instances of themselves. Not sure which approach is superior in this situation.