### PR TITLE
Support Zipkin HTTP B3 propagation format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes by Version
 1.6.1 (unreleased)
 -------------------
 
-- No changes yet
+- Add Zipkin HTTP B3 Propagation format support #72
 
 
 1.6.0 (2016-10-14)
@@ -32,5 +32,3 @@ Changes by Version
 -------------------
 
 - Support debug traces via HTTP header "jaeger-debug-id"
-
-

--- a/README.md
+++ b/README.md
@@ -113,13 +113,13 @@ are available:
      sampling rate.
   1. `RateLimitingSampler` can be used to allow only a certain fixed
      number of traces to be sampled per second.
-     
+
 ### Baggage Injection
 
 The OpenTracing spec allows for [baggage](http://opentracing.io/spec/#baggage),
 which are key value pairs that are added to the span context and propagated
 throughout the trace.
-An external process can inject baggage by setting the special 
+An external process can inject baggage by setting the special
 HTTP Header `jaeger-baggage` on a request
 
 ```sh
@@ -145,7 +145,7 @@ import (
     "github.com/opentracing/opentracing-go"
     "github.com/opentracing/opentracing-go/ext"
 )
-       
+
 span := opentracing.SpanFromContext(ctx)
 ext.SamplingPriority.Set(span, 1)    
 ```
@@ -162,7 +162,7 @@ curl -H "jaeger-debug-id: some-correlation-id" http://myhost.com
 When Jaeger sees this header in the request that otherwise has no
 tracing context, it ensures that the new trace started for this
 request will be sampled in the "debug" mode (meaning it should survive
-all downsampling that might happen in the collection pipeline), and the 
+all downsampling that might happen in the collection pipeline), and the
 root span will have a tag as if this statement was executed:
 
 ```go
@@ -171,11 +171,18 @@ span.SetTag("jaeger-debug-id", "some-correlation-id")
 
 This allows using Jaeger UI to find the trace by this tag.
 
+### Zipkin HTTP B3 compatible header propagation
+
+Jaeger Tracer supports Zipkin B3 Propagation HTTP headers, which are used
+by a lot of Zipkin tracers. This means that you can use Jaeger in conjunction with e.ge [these OpenZipkin tracers](https://github.com/openzipkin).
+
+However it is not the default propagation format, see [here](zipkin/README.MD#NewZipkinB3HTTPHeaderPropagator) how to set it up.
+
 ## License
-  
+
   [The MIT License](LICENSE).
 
-  
+
 [doc-img]: https://godoc.org/github.com/uber/jaeger-client-go?status.svg
 [doc]: https://godoc.org/github.com/uber/jaeger-client-go
 [ci-img]: https://travis-ci.org/uber/jaeger-client-go.svg?branch=master
@@ -184,4 +191,3 @@ This allows using Jaeger UI to find the trace by this tag.
 [cov]: https://coveralls.io/github/uber/jaeger-client-go?branch=master
 [ot-img]: https://github.com/opentracing/contrib/blob/master/badge/OpenTracing-enabled-blue.png
 [ot-url]: http://opentracing.io
-

--- a/zipkin/README.md
+++ b/zipkin/README.md
@@ -1,0 +1,30 @@
+# Zipkin compatibility features
+
+## `NewZipkinB3HTTPHeaderPropagator()`
+
+Adds support for injecting and extracting Zipkin B3 Propagation HTTP headers,
+for use with other Zipkin collectors.
+
+```go
+
+// ...
+import (
+  "github.com/uber/jaeger-client-go/zipkin"
+)
+
+func main() {
+	// ...
+	zipkinPropagator := zipkin.NewZipkinB3HTTPHeaderPropagator()
+	injector := jaeger.TracerOptions.Injector(opentracing.HTTPHeaders, zipkinPropagator)
+	extractor := jaeger.TracerOptions.Extractor(opentracing.HTTPHeaders, zipkinPropagator)
+
+	// create Jaeger tracer
+	tracer, closer := jaeger.NewTracer(
+		"myService",
+		mySampler, // as usual
+		myReporter // as usual
+		injector,
+		extractor,
+	)
+}
+```

--- a/zipkin/doc.go
+++ b/zipkin/doc.go
@@ -1,0 +1,2 @@
+// Package zipkin comprises Zipkin functionality for Zipkin compatiblity.
+package zipkin

--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -14,12 +14,12 @@ type Propagator struct{}
 
 // NewZipkinB3HTTPHeaderPropagator creates a Propagator for reading Zipkin
 // HTTP B3 headers
-func NewZipkinB3HTTPHeaderPropagator() *Propagator {
-	return &Propagator{}
+func NewZipkinB3HTTPHeaderPropagator() Propagator {
+	return Propagator{}
 }
 
 // Inject implements Inject()
-func (p *Propagator) Inject(
+func (p Propagator) Inject(
 	sc jaeger.SpanContext,
 	abstractCarrier interface{},
 ) error {
@@ -42,7 +42,7 @@ func (p *Propagator) Inject(
 }
 
 // Extract implements Extract()
-func (p *Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
+func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
 	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
 	if !ok {
 		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier

--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -1,0 +1,76 @@
+package zipkin
+
+import (
+	"strconv"
+	"strings"
+
+	opentracing "github.com/opentracing/opentracing-go"
+
+	"github.com/uber/jaeger-client-go"
+)
+
+// Propagator Injector and Extractor
+type Propagator struct{}
+
+// NewZipkinB3HTTPHeaderPropagator creates a Propagator for reading Zipkin
+// HTTP B3 headers
+func NewZipkinB3HTTPHeaderPropagator() *Propagator {
+	return &Propagator{}
+}
+
+// Inject implements Inject()
+func (p *Propagator) Inject(
+	sc jaeger.SpanContext,
+	abstractCarrier interface{},
+) error {
+	textMapWriter, ok := abstractCarrier.(opentracing.TextMapWriter)
+	if !ok {
+		return opentracing.ErrInvalidCarrier
+	}
+
+	textMapWriter.Set("x-b3-traceid", strconv.FormatUint(sc.TraceID(), 16))
+	if sc.ParentID() != 0 {
+		textMapWriter.Set("x-b3-parentspanid", strconv.FormatUint(sc.ParentID(), 16))
+	}
+	textMapWriter.Set("x-b3-spanid", strconv.FormatUint(sc.SpanID(), 16))
+	if sc.IsSampled() {
+		textMapWriter.Set("x-b3-sampled", "1")
+	} else {
+		textMapWriter.Set("x-b3-sampled", "0")
+	}
+	return nil
+}
+
+// Extract implements Extract()
+func (p *Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
+	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
+	if !ok {
+		return jaeger.SpanContext{}, opentracing.ErrInvalidCarrier
+	}
+	var traceID uint64
+	var spanID uint64
+	var parentID uint64
+	sampled := false
+	err := textMapReader.ForeachKey(func(rawKey, value string) error {
+		key := strings.ToLower(rawKey) // TODO not necessary for plain TextMap
+		var err error
+		if key == "x-b3-traceid" {
+			traceID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-parentspanid" {
+			parentID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-spanid" {
+			spanID, err = strconv.ParseUint(value, 16, 64)
+		} else if key == "x-b3-sampled" && value == "1" {
+			sampled = true
+		}
+		return err
+	})
+
+	if err != nil {
+		return jaeger.SpanContext{}, err
+	}
+	if traceID == 0 {
+		return jaeger.SpanContext{}, opentracing.ErrSpanContextNotFound
+	}
+	return jaeger.NewSpanContext(traceID, spanID, parentID, sampled, nil), nil
+}

--- a/zipkin/propagation.go
+++ b/zipkin/propagation.go
@@ -9,16 +9,16 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
-// Propagator Injector and Extractor
+// Propagator is an Injector and Extractor
 type Propagator struct{}
 
-// NewZipkinB3HTTPHeaderPropagator creates a Propagator for reading Zipkin
-// HTTP B3 headers
+// NewZipkinB3HTTPHeaderPropagator creates a Propagator for extracting and injecting
+// Zipkin HTTP B3 headers into SpanContexts.
 func NewZipkinB3HTTPHeaderPropagator() Propagator {
 	return Propagator{}
 }
 
-// Inject implements Inject()
+// Inject conforms to the Injector interface for decoding Zipkin HTTP B3 headers
 func (p Propagator) Inject(
 	sc jaeger.SpanContext,
 	abstractCarrier interface{},
@@ -41,7 +41,7 @@ func (p Propagator) Inject(
 	return nil
 }
 
-// Extract implements Extract()
+// Extract conforms to the Extractor interface for encoding Zipkin HTTP B3 headers
 func (p Propagator) Extract(abstractCarrier interface{}) (jaeger.SpanContext, error) {
 	textMapReader, ok := abstractCarrier.(opentracing.TextMapReader)
 	if !ok {

--- a/zipkin/propagation_test.go
+++ b/zipkin/propagation_test.go
@@ -1,0 +1,89 @@
+package zipkin
+
+import (
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-client-go"
+)
+
+var (
+	rootSampled       = jaeger.NewSpanContext(1, 2, 0, true, nil)
+	nonRootSampled    = jaeger.NewSpanContext(1, 2, 1, true, nil)
+	nonRootNonSampled = jaeger.NewSpanContext(1, 2, 1, false, nil)
+)
+
+var (
+	rootSampledHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid": "1",
+		"x-b3-spanid":  "2",
+		"x-b3-sampled": "1",
+	}
+	nonRootSampledHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid":      "1",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
+		"x-b3-sampled":      "1",
+	}
+	nonRootNonSampledHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid":      "1",
+		"x-b3-spanid":       "2",
+		"x-b3-parentspanid": "1",
+		"x-b3-sampled":      "0",
+	}
+	invalidHeader = opentracing.TextMapCarrier{
+		"x-b3-traceid":      "jdkafhsd",
+		"x-b3-spanid":       "afsdfsdf",
+		"x-b3-parentspanid": "hiagggdf",
+		"x-b3-sampled":      "sdfgsdfg",
+	}
+)
+
+var (
+	propagator = NewZipkinB3HTTPHeaderPropagator()
+)
+
+func TestExtractorInvalid(t *testing.T) {
+	_, err := propagator.Extract(invalidHeader)
+	assert.Error(t, err)
+}
+
+func TestExtractorRootSampled(t *testing.T) {
+	ctx, err := propagator.Extract(rootSampledHeader)
+	assert.Nil(t, err)
+	assert.EqualValues(t, rootSampled, ctx)
+}
+
+func TestExtractorNonRootSampled(t *testing.T) {
+	ctx, err := propagator.Extract(nonRootSampledHeader)
+	assert.Nil(t, err)
+	assert.EqualValues(t, nonRootSampled, ctx)
+}
+
+func TestExtractorNonRootNonSampled(t *testing.T) {
+	ctx, err := propagator.Extract(nonRootNonSampledHeader)
+	assert.Nil(t, err)
+	assert.EqualValues(t, nonRootNonSampled, ctx)
+}
+
+func TestInjectorRootSampled(t *testing.T) {
+	hdr := opentracing.TextMapCarrier{}
+	err := propagator.Inject(rootSampled, hdr)
+	assert.Nil(t, err)
+	assert.EqualValues(t, rootSampledHeader, hdr)
+}
+
+func TestInjectorNonRootSampled(t *testing.T) {
+	hdr := opentracing.TextMapCarrier{}
+	err := propagator.Inject(nonRootSampled, hdr)
+	assert.Nil(t, err)
+	assert.EqualValues(t, nonRootSampledHeader, hdr)
+}
+
+func TestInjectorNonRootNonSampled(t *testing.T) {
+	hdr := opentracing.TextMapCarrier{}
+	err := propagator.Inject(nonRootNonSampled, hdr)
+	assert.Nil(t, err)
+	assert.EqualValues(t, nonRootNonSampledHeader, hdr)
+}


### PR DESCRIPTION
This PR adds support for Jaeger to handle headers coming from Zipkin tracers.
It can inject, extract:
 - 64 bit TraceIds
 - 64 bit SpanIds
 - 64 bit ParentIds
 - Sampled flag

The functionality is basicly copied from my [earlier repo](https://github.com/szdavid92/jaeger-client-go-http-b3-propagation).