### PR TITLE
Fix sampling hostport for integration tests.

### DIFF
--- a/crossdock/endtoend/handler.go
+++ b/crossdock/endtoend/handler.go
@@ -40,7 +40,7 @@ var (
 		Sampler: &config.SamplerConfig{
 			Type:               jaeger.SamplerTypeRemote,
 			Param:              1.0,
-			LocalAgentHostPort: "test_driver:5778",
+			LocalAgentHostPort: "test_driver:5778/sampling",
 		},
 		Reporter: &config.ReporterConfig{
 			BufferFlushInterval: time.Second,

--- a/sampler.go
+++ b/sampler.go
@@ -399,7 +399,7 @@ func (s *httpSamplingManager) GetSamplingStrategy(serviceName string) (*sampling
 	var out sampling.SamplingStrategyResponse
 	v := url.Values{}
 	v.Set("service", serviceName)
-	if err := utils.GetJSON(s.serverURL+"/?"+v.Encode(), &out); err != nil {
+	if err := utils.GetJSON(s.serverURL+"?"+v.Encode(), &out); err != nil {
 		return nil, err
 	}
 	return &out, nil


### PR DESCRIPTION
Go client is using thrift 0.9.3 so it should use the /sampling endpoint when communicating with the host for integration tests.

There has to be another PR that appends "sampling" to the httpSamplingManager hostport