### PR TITLE
Add zap logger support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/transport"
 	"github.com/uber/jaeger-client-go/transport/udp"
 )
@@ -210,7 +211,7 @@ func (sc *SamplerConfig) NewSampler(
 func (rc *ReporterConfig) NewReporter(
 	serviceName string,
 	metrics *jaeger.Metrics,
-	logger jaeger.Logger,
+	logger log.Logger,
 ) (jaeger.Reporter, error) {
 	sender, err := rc.newTransport()
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -30,7 +30,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 
 	"github.com/uber/jaeger-client-go"
-	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/transport"
 	"github.com/uber/jaeger-client-go/transport/udp"
 )
@@ -211,7 +210,7 @@ func (sc *SamplerConfig) NewSampler(
 func (rc *ReporterConfig) NewReporter(
 	serviceName string,
 	metrics *jaeger.Metrics,
-	logger log.Logger,
+	logger jaeger.Logger,
 ) (jaeger.Reporter, error) {
 	sender, err := rc.newTransport()
 	if err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 
 	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/log"
 )
 
 func TestNewSamplerConst(t *testing.T) {
@@ -82,7 +83,7 @@ func TestInvalidSamplerType(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	cfg := Configuration{}
-	_, _, err := cfg.New("", Metrics(metrics.NullFactory), Logger(jaeger.NullLogger))
+	_, _, err := cfg.New("", Metrics(metrics.NullFactory), Logger(log.NullLogger))
 	require.EqualError(t, err, "no service name provided")
 
 	_, closer, err := cfg.New("testService")

--- a/crossdock/client/client_test.go
+++ b/crossdock/client/client_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/jaeger-client-go/crossdock/common"
 	"github.com/uber/jaeger-client-go/crossdock/log"
 	"github.com/uber/jaeger-client-go/crossdock/server"
+	jlog "github.com/uber/jaeger-client-go/log"
 )
 
 func TestCrossdock(t *testing.T) {
@@ -40,7 +41,7 @@ func TestCrossdock(t *testing.T) {
 
 	var reporter jaeger.Reporter
 	if log.Enabled {
-		reporter = jaeger.NewLoggingReporter(jaeger.StdLogger)
+		reporter = jaeger.NewLoggingReporter(jlog.StdLogger)
 	} else {
 		reporter = jaeger.NewNullReporter()
 	}

--- a/crossdock/endtoend/handler_test.go
+++ b/crossdock/endtoend/handler_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/config"
+	"github.com/uber/jaeger-client-go/log"
 )
 
 var (
@@ -99,7 +100,7 @@ func newInMemoryTracer() (opentracing.Tracer, *jaeger.InMemoryReporter) {
 		jaeger.NewConstSampler(true),
 		inMemoryReporter,
 		jaeger.TracerOptions.Metrics(jaeger.NewNullMetrics()),
-		jaeger.TracerOptions.Logger(jaeger.NullLogger))
+		jaeger.TracerOptions.Logger(log.NullLogger))
 	return tracer, inMemoryReporter
 }
 

--- a/crossdock/main.go
+++ b/crossdock/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/jaeger-client-go/crossdock/common"
 	"github.com/uber/jaeger-client-go/crossdock/log"
 	"github.com/uber/jaeger-client-go/crossdock/server"
+	jlog "github.com/uber/jaeger-client-go/log"
 )
 
 func main() {
@@ -54,6 +55,6 @@ func initTracer() (opentracing.Tracer, io.Closer) {
 	t, c := jaeger.NewTracer(
 		common.DefaultTracerServiceName,
 		jaeger.NewConstSampler(false),
-		jaeger.NewLoggingReporter(jaeger.StdLogger))
+		jaeger.NewLoggingReporter(jlog.StdLogger))
 	return t, c
 }

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 2d065dacbd72b291202f969bf78b2fdd099861b3f63304097d66d94266474d05
-updated: 2017-02-07T16:28:38.489805329-05:00
+updated: 2017-02-17T10:35:00.069472323-05:00
 imports:
 - name: github.com/apache/thrift
-  version: 3a8bbbd4a68fb28f2b33a7ee9e81ba3dd4a929a5
+  version: e8ba7877baec6f9871a88db8d3885361a2260ab2
   subpackages:
   - lib/go/thrift
 - name: github.com/codahale/hdrhistogram
@@ -50,6 +50,16 @@ imports:
   - trace/thrift/gen-go/tcollector
   - trand
   - typed
+- name: go.uber.org/atomic
+  version: 0c9e689d64f004564b79d9a663634756df322902
+- name: go.uber.org/zap
+  version: 066278dd4c1dedb5aa4dbc4a79df2651401810fd
+  subpackages:
+  - buffer
+  - internal/bufferpool
+  - internal/exit
+  - internal/multierror
+  - zapcore
 - name: golang.org/x/net
   version: 3b993948b6f0e651ffb58ba135d8538a68b1cddf
   subpackages:

--- a/log/logger.go
+++ b/log/logger.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package jaeger
+package log
 
 import "log"
 

--- a/log/logger_test.go
+++ b/log/logger_test.go
@@ -18,36 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package log
 
 import (
-	"github.com/uber/jaeger-lib/metrics"
-
-	"github.com/uber/jaeger-client-go"
-	"github.com/uber/jaeger-client-go/log"
+	"testing"
 )
 
-// ClientOption is a function that sets some option on the client.
-type ClientOption func(c *ClientOptions)
-
-// ClientOptions control behavior of the client.
-type ClientOptions struct {
-	metrics *jaeger.Metrics
-	logger  log.Logger
-}
-
-// Metrics creates a ClientOption that initializes Metrics in the client,
-// which is used to emit statistics.
-func Metrics(factory metrics.Factory) ClientOption {
-	return func(c *ClientOptions) {
-		c.metrics = jaeger.NewMetrics(factory, nil)
-	}
-}
-
-// Logger can be provided to log Reporter errors, as well as to log spans
-// if Reporter.LogSpans is set to true.
-func Logger(logger log.Logger) ClientOption {
-	return func(c *ClientOptions) {
-		c.logger = logger
+func TestLogger(t *testing.T) {
+	for _, logger := range []Logger{StdLogger, NullLogger} {
+		logger.Infof("Hi %s", "there")
+		logger.Error("Bad wolf")
 	}
 }

--- a/log/zap/logger.go
+++ b/log/zap/logger.go
@@ -18,36 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package zap
 
 import (
-	"github.com/uber/jaeger-lib/metrics"
+	"fmt"
 
-	"github.com/uber/jaeger-client-go"
-	"github.com/uber/jaeger-client-go/log"
+	"go.uber.org/zap"
 )
 
-// ClientOption is a function that sets some option on the client.
-type ClientOption func(c *ClientOptions)
-
-// ClientOptions control behavior of the client.
-type ClientOptions struct {
-	metrics *jaeger.Metrics
-	logger  log.Logger
+// Logger is an adapter from zap Logger to jaeger-lib Logger.
+type Logger struct {
+	logger zap.Logger
 }
 
-// Metrics creates a ClientOption that initializes Metrics in the client,
-// which is used to emit statistics.
-func Metrics(factory metrics.Factory) ClientOption {
-	return func(c *ClientOptions) {
-		c.metrics = jaeger.NewMetrics(factory, nil)
-	}
+// NewLogger creates a new Logger.
+func NewLogger(logger zap.Logger) *Logger {
+	return &Logger{logger: logger}
 }
 
-// Logger can be provided to log Reporter errors, as well as to log spans
-// if Reporter.LogSpans is set to true.
-func Logger(logger log.Logger) ClientOption {
-	return func(c *ClientOptions) {
-		c.logger = logger
-	}
+// Error logs a message at error priority
+func (l *Logger) Error(msg string) {
+	l.logger.Error(msg)
+}
+
+// Infof logs a message at info priority
+func (l *Logger) Infof(msg string, args ...interface{}) {
+	l.logger.Info(fmt.Sprintf(msg, args))
 }

--- a/log/zap/logger_test.go
+++ b/log/zap/logger_test.go
@@ -18,15 +18,17 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package jaeger
+package zap
 
 import (
 	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 func TestLogger(t *testing.T) {
-	for _, logger := range []Logger{StdLogger, NullLogger} {
-		logger.Infof("Hi %s", "there")
-		logger.Error("Bad wolf")
-	}
+	logger := NewLogger(*zap.New(zapcore.NewNopCore()))
+	logger.Infof("Hi %s", "there")
+	logger.Error("Bad wolf")
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package jaeger
+
+import "log"
+
+// NB This will be deprecated in 3.0.0, please use jaeger-client-go/log/logger instead.
+
+// Logger provides an abstract interface for logging from Reporters.
+// Applications can provide their own implementation of this interface to adapt
+// reporters logging to whatever logging library they prefer (stdlib log,
+// logrus, go-logging, etc).
+type Logger interface {
+	// Error logs a message at error priority
+	Error(msg string)
+
+	// Infof logs a message at info priority
+	Infof(msg string, args ...interface{})
+}
+
+// StdLogger is implementation of the Logger interface that delegates to default `log` package
+var StdLogger = &stdLogger{}
+
+type stdLogger struct{}
+
+func (l *stdLogger) Error(msg string) {
+	log.Printf("ERROR: %s", msg)
+}
+
+// Infof logs a message at info priority
+func (l *stdLogger) Infof(msg string, args ...interface{}) {
+	log.Printf(msg, args...)
+}
+
+// NullLogger is implementation of the Logger interface that delegates to default `log` package
+var NullLogger = &nullLogger{}
+
+type nullLogger struct{}
+
+func (l *nullLogger) Error(msg string)                      {}
+func (l *nullLogger) Infof(msg string, args ...interface{}) {}

--- a/logger_test.go
+++ b/logger_test.go
@@ -22,10 +22,24 @@ package jaeger
 
 import (
 	"testing"
+
+	"github.com/uber/jaeger-client-go/log"
 )
 
 func TestLogger(t *testing.T) {
 	for _, logger := range []Logger{StdLogger, NullLogger} {
+		logger.Infof("Hi %s", "there")
+		logger.Error("Bad wolf")
+	}
+}
+
+func TestCompatibility(t *testing.T) {
+	for _, logger := range []log.Logger{StdLogger, NullLogger} {
+		logger.Infof("Hi %s", "there")
+		logger.Error("Bad wolf")
+	}
+
+	for _, logger := range []Logger{log.StdLogger, log.NullLogger} {
 		logger.Infof("Hi %s", "there")
 		logger.Error("Bad wolf")
 	}

--- a/logger_test.go
+++ b/logger_test.go
@@ -18,35 +18,15 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package jaeger
 
 import (
-	"github.com/uber/jaeger-lib/metrics"
-
-	"github.com/uber/jaeger-client-go"
+	"testing"
 )
 
-// ClientOption is a function that sets some option on the client.
-type ClientOption func(c *ClientOptions)
-
-// ClientOptions control behavior of the client.
-type ClientOptions struct {
-	metrics *jaeger.Metrics
-	logger  jaeger.Logger
-}
-
-// Metrics creates a ClientOption that initializes Metrics in the client,
-// which is used to emit statistics.
-func Metrics(factory metrics.Factory) ClientOption {
-	return func(c *ClientOptions) {
-		c.metrics = jaeger.NewMetrics(factory, nil)
-	}
-}
-
-// Logger can be provided to log Reporter errors, as well as to log spans
-// if Reporter.LogSpans is set to true.
-func Logger(logger jaeger.Logger) ClientOption {
-	return func(c *ClientOptions) {
-		c.logger = logger
+func TestLogger(t *testing.T) {
+	for _, logger := range []Logger{StdLogger, NullLogger} {
+		logger.Infof("Hi %s", "there")
+		logger.Error("Bad wolf")
 	}
 }

--- a/reporter.go
+++ b/reporter.go
@@ -63,11 +63,11 @@ func (r *nullReporter) Close() {
 // ------------------------------
 
 type loggingReporter struct {
-	logger log.Logger
+	logger Logger
 }
 
 // NewLoggingReporter creates a reporter that logs all reported spans to provided logger.
-func NewLoggingReporter(logger log.Logger) Reporter {
+func NewLoggingReporter(logger Logger) Reporter {
 	return &loggingReporter{logger}
 }
 

--- a/reporter.go
+++ b/reporter.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 	"github.com/uber/jaeger-client-go/transport"
 )
@@ -62,11 +63,11 @@ func (r *nullReporter) Close() {
 // ------------------------------
 
 type loggingReporter struct {
-	logger Logger
+	logger log.Logger
 }
 
 // NewLoggingReporter creates a reporter that logs all reported spans to provided logger.
-func NewLoggingReporter(logger Logger) Reporter {
+func NewLoggingReporter(logger log.Logger) Reporter {
 	return &loggingReporter{logger}
 }
 
@@ -182,7 +183,7 @@ func NewRemoteReporter(sender transport.Transport, opts ...ReporterOption) Repor
 		options.bufferFlushInterval = defaultBufferFlushInterval
 	}
 	if options.logger == nil {
-		options.logger = NullLogger
+		options.logger = log.NullLogger
 	}
 	if options.metrics == nil {
 		options.metrics = NewNullMetrics()

--- a/reporter_options.go
+++ b/reporter_options.go
@@ -22,8 +22,6 @@ package jaeger
 
 import (
 	"time"
-
-	"github.com/uber/jaeger-client-go/log"
 )
 
 // ReporterOption is a function that sets some option on the reporter.
@@ -39,7 +37,7 @@ type reporterOptions struct {
 	// bufferFlushInterval is how often the buffer is force-flushed, even if it's not full
 	bufferFlushInterval time.Duration
 	// logger is used to log errors of span submissions
-	logger log.Logger
+	logger Logger
 	// metrics is used to record runtime stats
 	metrics *Metrics
 }
@@ -70,7 +68,7 @@ func (reporterOptions) BufferFlushInterval(bufferFlushInterval time.Duration) Re
 
 // Logger creates a ReporterOption that initializes the logger used to log
 // errors of span submissions.
-func (reporterOptions) Logger(logger log.Logger) ReporterOption {
+func (reporterOptions) Logger(logger Logger) ReporterOption {
 	return func(r *reporterOptions) {
 		r.logger = logger
 	}

--- a/reporter_options.go
+++ b/reporter_options.go
@@ -20,7 +20,11 @@
 
 package jaeger
 
-import "time"
+import (
+	"time"
+
+	"github.com/uber/jaeger-client-go/log"
+)
 
 // ReporterOption is a function that sets some option on the reporter.
 type ReporterOption func(c *reporterOptions)
@@ -35,7 +39,7 @@ type reporterOptions struct {
 	// bufferFlushInterval is how often the buffer is force-flushed, even if it's not full
 	bufferFlushInterval time.Duration
 	// logger is used to log errors of span submissions
-	logger Logger
+	logger log.Logger
 	// metrics is used to record runtime stats
 	metrics *Metrics
 }
@@ -66,7 +70,7 @@ func (reporterOptions) BufferFlushInterval(bufferFlushInterval time.Duration) Re
 
 // Logger creates a ReporterOption that initializes the logger used to log
 // errors of span submissions.
-func (reporterOptions) Logger(logger Logger) ReporterOption {
+func (reporterOptions) Logger(logger log.Logger) ReporterOption {
 	return func(r *reporterOptions) {
 		r.logger = logger
 	}

--- a/sampler.go
+++ b/sampler.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 	"github.com/uber/jaeger-client-go/utils"
 )
@@ -428,7 +429,7 @@ func applySamplerOptions(opts ...SamplerOption) samplerOptions {
 		options.sampler = initialSampler
 	}
 	if options.logger == nil {
-		options.logger = NullLogger
+		options.logger = log.NullLogger
 	}
 	if options.maxOperations <= 0 {
 		options.maxOperations = defaultMaxOperations

--- a/sampler_options.go
+++ b/sampler_options.go
@@ -22,8 +22,6 @@ package jaeger
 
 import (
 	"time"
-
-	"github.com/uber/jaeger-client-go/log"
 )
 
 // SamplerOption is a function that sets some option on the sampler
@@ -36,7 +34,7 @@ type samplerOptions struct {
 	metrics                 *Metrics
 	maxOperations           int
 	sampler                 Sampler
-	logger                  log.Logger
+	logger                  Logger
 	samplingServerURL       string
 	samplingRefreshInterval time.Duration
 }
@@ -66,7 +64,7 @@ func (samplerOptions) InitialSampler(sampler Sampler) SamplerOption {
 }
 
 // Logger creates a SamplerOption that sets the logger used by the sampler.
-func (samplerOptions) Logger(logger log.Logger) SamplerOption {
+func (samplerOptions) Logger(logger Logger) SamplerOption {
 	return func(o *samplerOptions) {
 		o.logger = logger
 	}

--- a/sampler_options.go
+++ b/sampler_options.go
@@ -20,7 +20,11 @@
 
 package jaeger
 
-import "time"
+import (
+	"time"
+
+	"github.com/uber/jaeger-client-go/log"
+)
 
 // SamplerOption is a function that sets some option on the sampler
 type SamplerOption func(options *samplerOptions)
@@ -32,7 +36,7 @@ type samplerOptions struct {
 	metrics                 *Metrics
 	maxOperations           int
 	sampler                 Sampler
-	logger                  Logger
+	logger                  log.Logger
 	samplingServerURL       string
 	samplingRefreshInterval time.Duration
 }
@@ -62,7 +66,7 @@ func (samplerOptions) InitialSampler(sampler Sampler) SamplerOption {
 }
 
 // Logger creates a SamplerOption that sets the logger used by the sampler.
-func (samplerOptions) Logger(logger Logger) SamplerOption {
+func (samplerOptions) Logger(logger log.Logger) SamplerOption {
 	return func(o *samplerOptions) {
 		o.logger = logger
 	}

--- a/sampler_test.go
+++ b/sampler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	mTestutils "github.com/uber/jaeger-lib/metrics/testutils"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/testutils"
 	"github.com/uber/jaeger-client-go/thrift-gen/sampling"
 	"github.com/uber/jaeger-client-go/utils"
@@ -293,7 +294,7 @@ func initAgent(t *testing.T) (*testutils.MockAgent, *RemotelyControlledSampler, 
 		SamplerOptions.SamplingServerURL("http://"+agent.SamplingServerAddr()),
 		SamplerOptions.MaxOperations(testDefaultMaxOperations),
 		SamplerOptions.InitialSampler(initialSampler),
-		SamplerOptions.Logger(NullLogger),
+		SamplerOptions.Logger(log.NullLogger),
 		SamplerOptions.SamplingRefreshInterval(time.Minute),
 	)
 	sampler.Close() // stop timer-based updates, we want to call them manually

--- a/tracer.go
+++ b/tracer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/opentracing/opentracing-go/ext"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/utils"
 )
 
@@ -41,7 +42,7 @@ type tracer struct {
 	sampler  Sampler
 	reporter Reporter
 	metrics  Metrics
-	logger   Logger
+	logger   log.Logger
 
 	timeNow      func() time.Time
 	randomNumber func() uint64
@@ -117,7 +118,7 @@ func NewTracer(
 		t.timeNow = time.Now
 	}
 	if t.logger == nil {
-		t.logger = NullLogger
+		t.logger = log.NullLogger
 	}
 	// TODO once on the new data model, support both v4 and v6 IPs
 	if t.hostIPv4 == 0 {

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -22,8 +22,6 @@ package jaeger
 
 import (
 	"time"
-
-	"github.com/uber/jaeger-client-go/log"
 )
 
 // TracerOption is a function that sets some option on the tracer
@@ -43,7 +41,7 @@ func (tracerOptions) Metrics(m *Metrics) TracerOption {
 }
 
 // Logger creates a TracerOption that gives the tracer a Logger.
-func (tracerOptions) Logger(logger log.Logger) TracerOption {
+func (tracerOptions) Logger(logger Logger) TracerOption {
 	return func(tracer *tracer) {
 		tracer.logger = logger
 	}

--- a/tracer_options.go
+++ b/tracer_options.go
@@ -20,7 +20,11 @@
 
 package jaeger
 
-import "time"
+import (
+	"time"
+
+	"github.com/uber/jaeger-client-go/log"
+)
 
 // TracerOption is a function that sets some option on the tracer
 type TracerOption func(tracer *tracer)
@@ -39,7 +43,7 @@ func (tracerOptions) Metrics(m *Metrics) TracerOption {
 }
 
 // Logger creates a TracerOption that gives the tracer a Logger.
-func (tracerOptions) Logger(logger Logger) TracerOption {
+func (tracerOptions) Logger(logger log.Logger) TracerOption {
 	return func(tracer *tracer) {
 		tracer.logger = logger
 	}

--- a/tracer_test.go
+++ b/tracer_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger-lib/metrics/testutils"
 
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/utils"
 )
 
@@ -203,7 +204,7 @@ func TestTracerOptions(t *testing.T) {
 	openTracer, closer := NewTracer("DOOP", // respect the classics, man!
 		NewConstSampler(true),
 		NewNullReporter(),
-		TracerOptions.Logger(StdLogger),
+		TracerOptions.Logger(log.StdLogger),
 		TracerOptions.TimeNow(timeNow),
 		TracerOptions.RandomNumber(rnd),
 		TracerOptions.PoolSpans(true),
@@ -211,7 +212,7 @@ func TestTracerOptions(t *testing.T) {
 	defer closer.Close()
 
 	tracer := openTracer.(*tracer)
-	assert.Equal(t, StdLogger, tracer.logger)
+	assert.Equal(t, log.StdLogger, tracer.logger)
 	assert.Equal(t, t1, tracer.timeNow())
 	assert.Equal(t, uint64(1), tracer.randomNumber())
 	assert.Equal(t, uint64(1), tracer.randomNumber())

--- a/transport/zipkin/example_test.go
+++ b/transport/zipkin/example_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber/jaeger-client-go"
+	jlog "github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/transport/zipkin"
 )
 
@@ -34,7 +35,7 @@ func ExampleNewHTTPTransport() {
 	transport, err := zipkin.NewHTTPTransport(
 		"http://localhost:9411/api/v1/spans",
 		zipkin.HTTPBatchSize(10),
-		zipkin.HTTPLogger(jaeger.StdLogger),
+		zipkin.HTTPLogger(jlog.StdLogger),
 	)
 	if err != nil {
 		log.Fatalf("Cannot initialize Zipkin HTTP transport: %v", err)

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
-	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 	"github.com/uber/jaeger-client-go/transport"
 )
@@ -42,7 +42,7 @@ const defaultHTTPTimeout = time.Second * 5
 
 // HTTPTransport implements Transport by forwarding spans to a http server.
 type HTTPTransport struct {
-	logger    jaeger.Logger
+	logger    log.Logger
 	url       string
 	client    *http.Client
 	batchSize int
@@ -55,7 +55,7 @@ type HTTPOption func(c *HTTPTransport)
 // HTTPLogger sets the logger used to report errors in the collection
 // process. By default, a no-op logger is used, i.e. no errors are logged
 // anywhere. It's important to set this option in a production service.
-func HTTPLogger(logger jaeger.Logger) HTTPOption {
+func HTTPLogger(logger log.Logger) HTTPOption {
 	return func(c *HTTPTransport) { c.logger = logger }
 }
 
@@ -75,7 +75,7 @@ func HTTPBatchSize(n int) HTTPOption {
 //     http://hostname:9411/api/v1/spans
 func NewHTTPTransport(url string, options ...HTTPOption) (transport.Transport, error) {
 	c := &HTTPTransport{
-		logger:    jaeger.NullLogger,
+		logger:    log.NullLogger,
 		url:       url,
 		client:    &http.Client{Timeout: defaultHTTPTimeout},
 		batchSize: 100,

--- a/transport/zipkin/http.go
+++ b/transport/zipkin/http.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/apache/thrift/lib/go/thrift"
 
+	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 	"github.com/uber/jaeger-client-go/transport"
@@ -42,7 +43,7 @@ const defaultHTTPTimeout = time.Second * 5
 
 // HTTPTransport implements Transport by forwarding spans to a http server.
 type HTTPTransport struct {
-	logger    log.Logger
+	logger    jaeger.Logger
 	url       string
 	client    *http.Client
 	batchSize int
@@ -55,7 +56,7 @@ type HTTPOption func(c *HTTPTransport)
 // HTTPLogger sets the logger used to report errors in the collection
 // process. By default, a no-op logger is used, i.e. no errors are logged
 // anywhere. It's important to set this option in a production service.
-func HTTPLogger(logger log.Logger) HTTPOption {
+func HTTPLogger(logger jaeger.Logger) HTTPOption {
 	return func(c *HTTPTransport) { c.logger = logger }
 }
 

--- a/transport/zipkin/http_test.go
+++ b/transport/zipkin/http_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/jaeger-client-go"
+	"github.com/uber/jaeger-client-go/log"
 	"github.com/uber/jaeger-client-go/thrift-gen/zipkincore"
 )
 
@@ -82,12 +83,12 @@ func TestHttpTransport(t *testing.T) {
 func TestHTTPOptions(t *testing.T) {
 	sender, err := NewHTTPTransport(
 		"some url",
-		HTTPLogger(jaeger.StdLogger),
+		HTTPLogger(log.StdLogger),
 		HTTPBatchSize(123),
 		HTTPTimeout(123*time.Millisecond),
 	)
 	require.NoError(t, err)
-	assert.Equal(t, jaeger.StdLogger, sender.(*HTTPTransport).logger)
+	assert.Equal(t, log.StdLogger, sender.(*HTTPTransport).logger)
 	assert.Equal(t, 123, sender.(*HTTPTransport).batchSize)
 	assert.Equal(t, 123*time.Millisecond, sender.(*HTTPTransport).client.Timeout)
 }


### PR DESCRIPTION
This is a breaking change, we should maybe consider keeping the original log as is and add the zap-log directory, or rererelease 2.0.0 again