### PR TITLE
Make zap logger more efficient

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 2d065dacbd72b291202f969bf78b2fdd099861b3f63304097d66d94266474d05
-updated: 2017-02-17T10:35:00.069472323-05:00
+updated: 2017-02-21T10:46:43.195205158-05:00
 imports:
 - name: github.com/apache/thrift
-  version: e8ba7877baec6f9871a88db8d3885361a2260ab2
+  version: bc0082e02357de2f30b997188bdfa94d703331f4
   subpackages:
   - lib/go/thrift
 - name: github.com/codahale/hdrhistogram
@@ -53,7 +53,7 @@ imports:
 - name: go.uber.org/atomic
   version: 0c9e689d64f004564b79d9a663634756df322902
 - name: go.uber.org/zap
-  version: 066278dd4c1dedb5aa4dbc4a79df2651401810fd
+  version: c55503708841efe770d8fe5ae3817004ce71411f
   subpackages:
   - buffer
   - internal/bufferpool

--- a/log/zap/logger.go
+++ b/log/zap/logger.go
@@ -21,19 +21,17 @@
 package zap
 
 import (
-	"fmt"
-
 	"go.uber.org/zap"
 )
 
 // Logger is an adapter from zap Logger to jaeger-lib Logger.
 type Logger struct {
-	logger zap.Logger
+	logger *zap.SugaredLogger
 }
 
 // NewLogger creates a new Logger.
-func NewLogger(logger zap.Logger) *Logger {
-	return &Logger{logger: logger}
+func NewLogger(logger *zap.Logger) *Logger {
+	return &Logger{logger: logger.Sugar()}
 }
 
 // Error logs a message at error priority
@@ -43,5 +41,5 @@ func (l *Logger) Error(msg string) {
 
 // Infof logs a message at info priority
 func (l *Logger) Infof(msg string, args ...interface{}) {
-	l.logger.Info(fmt.Sprintf(msg, args))
+	l.logger.Infof(msg, args)
 }

--- a/log/zap/logger_test.go
+++ b/log/zap/logger_test.go
@@ -24,11 +24,10 @@ import (
 	"testing"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 func TestLogger(t *testing.T) {
-	logger := NewLogger(*zap.New(zapcore.NewNopCore()))
+	logger := NewLogger(zap.NewNop())
 	logger.Infof("Hi %s", "there")
 	logger.Error("Bad wolf")
 }


### PR DESCRIPTION
Addressing the comments from: https://github.com/uber/jaeger-client-go/pull/93