### PR TITLE
Make Span type public to allow access to non-std methods for testing

### DIFF
--- a/observer_test.go
+++ b/observer_test.go
@@ -33,7 +33,7 @@ func TestEmptyObserver(t *testing.T) {
 	defer closer.Close()
 	s := tracer.StartSpan("test", ext.RPCServerOption(nil))
 	s.Finish()
-	assert.Equal(t, s.(*span).observer, noopSpanObserver)
+	assert.Equal(t, s.(*Span).observer, noopSpanObserver)
 }
 
 func TestObservers(t *testing.T) {
@@ -49,7 +49,7 @@ func TestObservers(t *testing.T) {
 	s := tracer.StartSpan("test", ext.RPCServerOption(nil))
 
 	forEachObs := func(f func(so *testSpanObserver)) {
-		observers := s.(*span).observer.(spanObserver).observers
+		observers := s.(*Span).observer.(spanObserver).observers
 		assert.Len(t, observers, 2)
 		for _, so := range observers {
 			f(so.(*testSpanObserver))

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -77,9 +77,9 @@ func TestSpanPropagator(t *testing.T) {
 	otSpans := reporter.GetSpans()
 	require.Equal(t, len(tests)+1, len(otSpans), "unexpected number of spans reporter")
 
-	spans := make([]*span, len(otSpans))
+	spans := make([]*Span, len(otSpans))
 	for i, s := range otSpans {
-		spans[i] = s.(*span)
+		spans[i] = s.(*Span)
 	}
 
 	// The last span is the original one.
@@ -158,9 +158,9 @@ func TestBaggagePropagationHTTP(t *testing.T) {
 
 	sp1 := tracer.StartSpan("s1")
 	sp1.SetBaggageItem("Some_Key", "12345")
-	assert.Equal(t, "12345", sp1.BaggageItem("some-KEY"), "baggage: %+v", sp1.(*span).context.baggage)
+	assert.Equal(t, "12345", sp1.BaggageItem("some-KEY"), "baggage: %+v", sp1.(*Span).context.baggage)
 	sp1.SetBaggageItem("Some_Key", "98:765") // colon : should be escaped as %3A
-	assert.Equal(t, "98:765", sp1.BaggageItem("some-KEY"), "baggage: %+v", sp1.(*span).context.baggage)
+	assert.Equal(t, "98:765", sp1.BaggageItem("some-KEY"), "baggage: %+v", sp1.(*Span).context.baggage)
 
 	h := http.Header{}
 	h.Add("header1", "value1") // make sure this does not get unmarshalled as baggage
@@ -189,7 +189,7 @@ func TestJaegerBaggageHeader(t *testing.T) {
 	ctx, err := tracer.Extract(opentracing.HTTPHeaders, opentracing.HTTPHeadersCarrier(h))
 	require.NoError(t, err)
 
-	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*span)
+	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
 
 	assert.Equal(t, "value1", sp.BaggageItem("key1"))
 	assert.Equal(t, "value two", sp.BaggageItem("key 2"))
@@ -238,7 +238,7 @@ func TestDebugCorrelationID(t *testing.T) {
 	require.NoError(t, err)
 	assert.EqualValues(t, 0, ctx.(SpanContext).parentID)
 	assert.EqualValues(t, "value1", ctx.(SpanContext).debugID)
-	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*span)
+	sp := tracer.StartSpan("root", opentracing.ChildOf(ctx)).(*Span)
 	assert.EqualValues(t, 0, sp.context.parentID)
 	assert.True(t, sp.context.traceID.IsValid())
 	assert.True(t, sp.context.IsSampled())

--- a/reporter_test.go
+++ b/reporter_test.go
@@ -128,7 +128,7 @@ func (s *reporterSuite) TestClientSpanAnnotations() {
 	s.flushReporter()
 	s.Equal(2, len(s.collector.Spans()))
 	zSpan := s.collector.Spans()[0] // child span is reported first
-	s.EqualValues(zSpan.ID, sp2.(*span).context.spanID)
+	s.EqualValues(zSpan.ID, sp2.(*Span).context.spanID)
 	s.Equal(2, len(zSpan.Annotations), "expecting two annotations, cs and cr")
 	s.Equal(1, len(zSpan.BinaryAnnotations), "expecting one binary annotation sa")
 	s.NotNil(findAnnotation(zSpan, "cs"), "expecting cs annotation")
@@ -256,7 +256,7 @@ func (s *reporterSuite) TestMemoryReporterReport() {
 	sp := s.tracer.StartSpan("leela")
 	ext.PeerService.Set(sp, s.serviceName)
 	reporter := NewInMemoryReporter()
-	reporter.Report(sp.(*span))
+	reporter.Report(sp.(*Span))
 	s.Equal(1, reporter.SpansSubmitted(), "expected number of spans submitted")
 	reporter.Close()
 }

--- a/span.go
+++ b/span.go
@@ -32,7 +32,8 @@ import (
 	"github.com/uber/jaeger-client-go/utils"
 )
 
-type span struct {
+// Span implements opentracing.Span
+type Span struct {
 	sync.RWMutex
 
 	tracer *tracer
@@ -82,8 +83,8 @@ type Tag struct {
 	value interface{}
 }
 
-// Sets or changes the operation name.
-func (s *span) SetOperationName(operationName string) opentracing.Span {
+// SetOperationName sets or changes the operation name.
+func (s *Span) SetOperationName(operationName string) opentracing.Span {
 	s.Lock()
 	defer s.Unlock()
 	if s.context.IsSampled() {
@@ -94,7 +95,7 @@ func (s *span) SetOperationName(operationName string) opentracing.Span {
 }
 
 // SetTag implements SetTag() of opentracing.Span
-func (s *span) SetTag(key string, value interface{}) opentracing.Span {
+func (s *Span) SetTag(key string, value interface{}) opentracing.Span {
 	s.observer.OnSetTag(key, value)
 	if key == string(ext.SamplingPriority) && setSamplingPriority(s, key, value) {
 		return s
@@ -107,7 +108,7 @@ func (s *span) SetTag(key string, value interface{}) opentracing.Span {
 	return s
 }
 
-func (s *span) setTagNoLocking(key string, value interface{}) {
+func (s *Span) setTagNoLocking(key string, value interface{}) {
 	handled := false
 	if handler, ok := specialTagHandlers[key]; ok {
 		handled = handler(s, key, value)
@@ -117,7 +118,7 @@ func (s *span) setTagNoLocking(key string, value interface{}) {
 	}
 }
 
-func (s *span) setTracerTags(tags []Tag) {
+func (s *Span) setTracerTags(tags []Tag) {
 	s.Lock()
 	for _, tag := range tags {
 		s.tags = append(s.tags, tag)
@@ -125,7 +126,8 @@ func (s *span) setTracerTags(tags []Tag) {
 	s.Unlock()
 }
 
-func (s *span) LogFields(fields ...log.Field) {
+// LogFields implements opentracing.Span API
+func (s *Span) LogFields(fields ...log.Field) {
 	s.Lock()
 	defer s.Unlock()
 	if !s.context.IsSampled() {
@@ -138,7 +140,8 @@ func (s *span) LogFields(fields ...log.Field) {
 	s.appendLog(lr)
 }
 
-func (s *span) LogKV(alternatingKeyValues ...interface{}) {
+// LogKV implements opentracing.Span API
+func (s *Span) LogKV(alternatingKeyValues ...interface{}) {
 	s.RLock()
 	sampled := s.context.IsSampled()
 	s.RUnlock()
@@ -153,15 +156,18 @@ func (s *span) LogKV(alternatingKeyValues ...interface{}) {
 	s.LogFields(fields...)
 }
 
-func (s *span) LogEvent(event string) {
+// LogEvent implements opentracing.Span API
+func (s *Span) LogEvent(event string) {
 	s.Log(opentracing.LogData{Event: event})
 }
 
-func (s *span) LogEventWithPayload(event string, payload interface{}) {
+// LogEventWithPayload implements opentracing.Span API
+func (s *Span) LogEventWithPayload(event string, payload interface{}) {
 	s.Log(opentracing.LogData{Event: event, Payload: payload})
 }
 
-func (s *span) Log(ld opentracing.LogData) {
+// Log implements opentracing.Span API
+func (s *Span) Log(ld opentracing.LogData) {
 	s.Lock()
 	defer s.Unlock()
 	if s.context.IsSampled() {
@@ -173,13 +179,13 @@ func (s *span) Log(ld opentracing.LogData) {
 }
 
 // this function should only be called while holding a Write lock
-func (s *span) appendLog(lr opentracing.LogRecord) {
+func (s *Span) appendLog(lr opentracing.LogRecord) {
 	// TODO add logic to limit number of logs per span (issue #46)
 	s.logs = append(s.logs, lr)
 }
 
 // SetBaggageItem implements SetBaggageItem() of opentracing.SpanContext
-func (s *span) SetBaggageItem(key, value string) opentracing.Span {
+func (s *Span) SetBaggageItem(key, value string) opentracing.Span {
 	key = normalizeBaggageKey(key)
 	s.Lock()
 	defer s.Unlock()
@@ -188,18 +194,20 @@ func (s *span) SetBaggageItem(key, value string) opentracing.Span {
 }
 
 // BaggageItem implements BaggageItem() of opentracing.SpanContext
-func (s *span) BaggageItem(key string) string {
+func (s *Span) BaggageItem(key string) string {
 	key = normalizeBaggageKey(key)
 	s.RLock()
 	defer s.RUnlock()
 	return s.context.baggage[key]
 }
 
-func (s *span) Finish() {
+// Finish implements opentracing.Span API
+func (s *Span) Finish() {
 	s.FinishWithOptions(opentracing.FinishOptions{})
 }
 
-func (s *span) FinishWithOptions(options opentracing.FinishOptions) {
+// FinishWithOptions implements opentracing.Span API
+func (s *Span) FinishWithOptions(options opentracing.FinishOptions) {
 	if options.FinishTime.IsZero() {
 		options.FinishTime = s.tracer.timeNow()
 	}
@@ -220,42 +228,53 @@ func (s *span) FinishWithOptions(options opentracing.FinishOptions) {
 	s.tracer.reportSpan(s)
 }
 
-func (s *span) Context() opentracing.SpanContext {
+// Context implements opentracing.Span API
+func (s *Span) Context() opentracing.SpanContext {
 	return s.context
 }
 
-func (s *span) Tracer() opentracing.Tracer {
+// Tracer implements opentracing.Span API
+func (s *Span) Tracer() opentracing.Tracer {
 	return s.tracer
 }
 
-func (s *span) String() string {
+func (s *Span) String() string {
+	s.RLock()
+	defer s.RUnlock()
 	return s.context.String()
 }
 
-func (s *span) peerDefined() bool {
+// OperationName allows retrieving current operation name.
+func (s *Span) OperationName() string {
+	s.RLock()
+	defer s.RUnlock()
+	return s.operationName
+}
+
+func (s *Span) peerDefined() bool {
 	return s.peer.ServiceName != "" || s.peer.Ipv4 != 0 || s.peer.Port != 0
 }
 
-func (s *span) isRPC() bool {
+func (s *Span) isRPC() bool {
 	s.RLock()
 	defer s.RUnlock()
 	return s.spanKind == string(ext.SpanKindRPCClientEnum) || s.spanKind == string(ext.SpanKindRPCServerEnum)
 }
 
-func (s *span) isRPCClient() bool {
+func (s *Span) isRPCClient() bool {
 	s.RLock()
 	defer s.RUnlock()
 	return s.spanKind == string(ext.SpanKindRPCClientEnum)
 }
 
-var specialTagHandlers = map[string]func(*span, string, interface{}) bool{
+var specialTagHandlers = map[string]func(*Span, string, interface{}) bool{
 	string(ext.SpanKind):     setSpanKind,
 	string(ext.PeerHostIPv4): setPeerIPv4,
 	string(ext.PeerPort):     setPeerPort,
 	string(ext.PeerService):  setPeerService,
 }
 
-func setSpanKind(s *span, key string, value interface{}) bool {
+func setSpanKind(s *Span, key string, value interface{}) bool {
 	if val, ok := value.(string); ok {
 		s.spanKind = val
 		return true
@@ -267,7 +286,7 @@ func setSpanKind(s *span, key string, value interface{}) bool {
 	return false
 }
 
-func setPeerIPv4(s *span, key string, value interface{}) bool {
+func setPeerIPv4(s *Span, key string, value interface{}) bool {
 	if val, ok := value.(string); ok {
 		if ip, err := utils.ParseIPToUint32(val); err == nil {
 			s.peer.Ipv4 = int32(ip)
@@ -285,7 +304,7 @@ func setPeerIPv4(s *span, key string, value interface{}) bool {
 	return false
 }
 
-func setPeerPort(s *span, key string, value interface{}) bool {
+func setPeerPort(s *Span, key string, value interface{}) bool {
 	if val, ok := value.(string); ok {
 		if port, err := utils.ParsePort(val); err == nil {
 			s.peer.Port = int16(port)
@@ -303,7 +322,7 @@ func setPeerPort(s *span, key string, value interface{}) bool {
 	return false
 }
 
-func setPeerService(s *span, key string, value interface{}) bool {
+func setPeerService(s *Span, key string, value interface{}) bool {
 	if val, ok := value.(string); ok {
 		s.peer.ServiceName = val
 		return true
@@ -311,7 +330,7 @@ func setPeerService(s *span, key string, value interface{}) bool {
 	return false
 }
 
-func setSamplingPriority(s *span, key string, value interface{}) bool {
+func setSamplingPriority(s *Span, key string, value interface{}) bool {
 	s.Lock()
 	defer s.Unlock()
 	if val, ok := value.(uint16); ok {

--- a/span_test.go
+++ b/span_test.go
@@ -31,7 +31,7 @@ func TestBaggageIterator(t *testing.T) {
 	tracer, closer := NewTracer("DOOP", NewConstSampler(true), NewNullReporter())
 	defer closer.Close()
 
-	sp1 := tracer.StartSpan("s1").(*span)
+	sp1 := tracer.StartSpan("s1").(*Span)
 	sp1.SetBaggageItem("Some_Key", "12345")
 	sp1.SetBaggageItem("Some-other-key", "42")
 	expectedBaggage := map[string]string{"some-key": "12345", "some-other-key": "42"}
@@ -62,7 +62,7 @@ func TestSpanProperties(t *testing.T) {
 	tracer, closer := NewTracer("DOOP", NewConstSampler(true), NewNullReporter())
 	defer closer.Close()
 
-	sp1 := tracer.StartSpan("s1").(*span)
+	sp1 := tracer.StartSpan("s1").(*Span)
 	assert.Equal(t, tracer, sp1.Tracer())
 	assert.NotNil(t, sp1.Context())
 }

--- a/span_test.go
+++ b/span_test.go
@@ -66,3 +66,14 @@ func TestSpanProperties(t *testing.T) {
 	assert.Equal(t, tracer, sp1.Tracer())
 	assert.NotNil(t, sp1.Context())
 }
+
+func TestSpanOperationName(t *testing.T) {
+	tracer, closer := NewTracer("DOOP", NewConstSampler(true), NewNullReporter())
+	defer closer.Close()
+
+	sp1 := tracer.StartSpan("s1").(*Span)
+	sp1.SetOperationName("s2")
+	sp1.Finish()
+
+	assert.Equal(t, "s2", sp1.OperationName())
+}

--- a/thrift_span.go
+++ b/thrift_span.go
@@ -40,7 +40,7 @@ const (
 )
 
 // buildThriftSpan builds thrift span based on internal span.
-func buildThriftSpan(span *span) *z.Span {
+func buildThriftSpan(span *Span) *z.Span {
 	parentID := int64(span.context.parentID)
 	var ptrParentID *int64
 	if parentID != 0 {
@@ -64,7 +64,7 @@ func buildThriftSpan(span *span) *z.Span {
 	return thriftSpan
 }
 
-func buildAnnotations(span *span, endpoint *z.Endpoint) []*z.Annotation {
+func buildAnnotations(span *Span, endpoint *z.Endpoint) []*z.Annotation {
 	// automatically adding 2 Zipkin CoreAnnotations
 	annotations := make([]*z.Annotation, 0, 2+len(span.logs))
 	var startLabel, endLabel string
@@ -102,7 +102,7 @@ func buildAnnotations(span *span, endpoint *z.Endpoint) []*z.Annotation {
 	return annotations
 }
 
-func buildBinaryAnnotations(span *span, endpoint *z.Endpoint) []*z.BinaryAnnotation {
+func buildBinaryAnnotations(span *Span, endpoint *z.Endpoint) []*z.BinaryAnnotation {
 	// automatically adding local component or server/client address tag, and client version
 	annotations := make([]*z.BinaryAnnotation, 0, 2+len(span.tags))
 

--- a/thrift_span_test.go
+++ b/thrift_span_test.go
@@ -41,13 +41,13 @@ func TestThriftFirstInProcessSpan(t *testing.T) {
 		NewNullReporter())
 	defer closer.Close()
 
-	sp1 := tracer.StartSpan("s1").(*span)
-	sp2 := tracer.StartSpan("sp2", opentracing.ChildOf(sp1.Context())).(*span)
+	sp1 := tracer.StartSpan("s1").(*Span)
+	sp2 := tracer.StartSpan("sp2", opentracing.ChildOf(sp1.Context())).(*Span)
 	sp2.Finish()
 	sp1.Finish()
 
 	tests := []struct {
-		span     *span
+		span     *Span
 		wantTags bool
 	}{
 		{sp1, true},
@@ -75,7 +75,7 @@ func TestThriftForceSampled(t *testing.T) {
 		NewNullReporter())
 	defer closer.Close()
 
-	sp := tracer.StartSpan("s1").(*span)
+	sp := tracer.StartSpan("s1").(*Span)
 	ext.SamplingPriority.Set(sp, 1)
 	assert.True(t, sp.context.IsSampled())
 	assert.True(t, sp.context.IsDebug())
@@ -227,7 +227,7 @@ func TestThriftSpanLogs(t *testing.T) {
 		} else if len(test.fields) > 0 {
 			sp.LogFields(test.fields...)
 		}
-		thriftSpan := buildThriftSpan(sp.(*span))
+		thriftSpan := buildThriftSpan(sp.(*Span))
 		if test.disableSampling {
 			assert.Equal(t, 0, len(thriftSpan.Annotations), testName)
 			continue
@@ -255,7 +255,7 @@ func TestThriftLocalComponentSpan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		sp := tracer.StartSpan("s1").(*span)
+		sp := tracer.StartSpan("s1").(*Span)
 		if test.addComponentTag {
 			ext.Component.Set(sp, "c1")
 		}

--- a/tracer.go
+++ b/tracer.go
@@ -80,7 +80,7 @@ func NewTracer(
 		extractors:  make(map[interface{}]Extractor),
 		metrics:     *NewNullMetrics(),
 		spanPool: sync.Pool{New: func() interface{} {
-			return &span{}
+			return &Span{}
 		}},
 	}
 
@@ -270,11 +270,11 @@ func (t *tracer) Close() error {
 
 // newSpan returns an instance of a clean Span object.
 // If options.PoolSpans is true, the spans are retrieved from an object pool.
-func (t *tracer) newSpan() *span {
+func (t *tracer) newSpan() *Span {
 	if !t.options.poolSpans {
-		return &span{}
+		return &Span{}
 	}
-	sp := t.spanPool.Get().(*span)
+	sp := t.spanPool.Get().(*Span)
 	sp.context = emptyContext
 	sp.tracer = nil
 	sp.tags = nil
@@ -283,14 +283,14 @@ func (t *tracer) newSpan() *span {
 }
 
 func (t *tracer) startSpanInternal(
-	sp *span,
+	sp *Span,
 	operationName string,
 	startTime time.Time,
 	internalTags []Tag,
 	tags opentracing.Tags,
 	newTrace bool,
 	rpcServer bool,
-) opentracing.Span {
+) *Span {
 	sp.tracer = t
 	sp.operationName = operationName
 	sp.startTime = startTime
@@ -331,7 +331,7 @@ func (t *tracer) startSpanInternal(
 	return sp
 }
 
-func (t *tracer) reportSpan(sp *span) {
+func (t *tracer) reportSpan(sp *Span) {
 	t.metrics.SpansFinished.Inc(1)
 	if sp.context.IsSampled() {
 		if sp.firstInProcess {

--- a/zipkin_test.go
+++ b/zipkin_test.go
@@ -38,7 +38,7 @@ func TestZipkinPropagator(t *testing.T) {
 	if err := tracer.Inject(sp.Context(), "zipkin-span-format", carrier); err != nil {
 		t.Fatalf("Inject failed: %+v", err)
 	}
-	sp1 := sp.(*span)
+	sp1 := sp.(*Span)
 	assert.Equal(t, sp1.context.traceID, TraceID{Low: carrier.traceID})
 	assert.Equal(t, sp1.context.spanID, SpanID(carrier.spanID))
 	assert.Equal(t, sp1.context.parentID, SpanID(carrier.parentID))
@@ -49,7 +49,7 @@ func TestZipkinPropagator(t *testing.T) {
 		t.Fatalf("Extract failed: %+v", err)
 	}
 	sp2 := tracer.StartSpan("x", ext.RPCServerOption(sp2ctx))
-	sp3 := sp2.(*span)
+	sp3 := sp2.(*Span)
 	assert.Equal(t, sp1.context.traceID, sp3.context.traceID)
 	assert.Equal(t, sp1.context.spanID, sp3.context.spanID)
 	assert.Equal(t, sp1.context.parentID, sp3.context.parentID)


### PR DESCRIPTION
For example, allow access to span.OperationName(), introduced in the same PR