### PR TITLE
Add config option to initialize RPC Metrics feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes by Version
 2.5.1 (unreleased)
 ------------------
 
-- Nothing yet
+- Add config option to initialize RPC Metrics feature
 
 
 2.5.0 (2017-03-23)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,12 +24,12 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
 	"github.com/uber/jaeger-lib/metrics/testutils"
 
-	"github.com/opentracing/opentracing-go/ext"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/log"
 )

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -24,9 +24,12 @@ import (
 	"testing"
 
 	"github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/uber/jaeger-lib/metrics"
+	"github.com/uber/jaeger-lib/metrics/testutils"
 
+	"github.com/opentracing/opentracing-go/ext"
 	"github.com/uber/jaeger-client-go"
 	"github.com/uber/jaeger-client-go/log"
 )
@@ -135,4 +138,45 @@ func TestInitGlobalTracer(t *testing.T) {
 			require.Equal(t, noopTracer, opentracing.GlobalTracer())
 		}
 	}
+}
+
+func TestConfigWithReporter(t *testing.T) {
+	c := Configuration{
+		Sampler: &SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+	}
+	r := jaeger.NewInMemoryReporter()
+	tracer, closer, err := c.New("test", Reporter(r))
+	require.NoError(t, err)
+	defer closer.Close()
+
+	tracer.StartSpan("test").Finish()
+	assert.Len(t, r.GetSpans(), 1)
+}
+
+func TestConfigWithRPCMetrics(t *testing.T) {
+	metrics := metrics.NewLocalFactory(0)
+	c := Configuration{
+		Sampler: &SamplerConfig{
+			Type:  "const",
+			Param: 1,
+		},
+		RPCMetrics: true,
+	}
+	r := jaeger.NewInMemoryReporter()
+	tracer, closer, err := c.New("test", Reporter(r), Metrics(metrics))
+	require.NoError(t, err)
+	defer closer.Close()
+
+	tracer.StartSpan("test", ext.SpanKindRPCServer).Finish()
+
+	testutils.AssertCounterMetrics(t, metrics,
+		testutils.ExpectedMetric{
+			Name:  "jaeger-rpc.requests",
+			Tags:  map[string]string{"component": "jaeger", "endpoint": "test", "error": "false"},
+			Value: 1,
+		},
+	)
 }

--- a/config/options.go
+++ b/config/options.go
@@ -37,8 +37,8 @@ type Options struct {
 	observers []jaeger.Observer
 }
 
-// Metrics creates a Option that initializes Metrics in the client,
-// which is used to emit statistics.
+// Metrics creates an Option that initializes Metrics in the tracer,
+// which is used to emit statistics about spans.
 func Metrics(factory metrics.Factory) Option {
 	return func(c *Options) {
 		c.metrics = factory

--- a/config/options.go
+++ b/config/options.go
@@ -26,35 +26,58 @@ import (
 	"github.com/uber/jaeger-client-go"
 )
 
-// ClientOption is a function that sets some option on the client.
-type ClientOption func(c *ClientOptions)
+// Option is a function that sets some option on the client.
+type Option func(c *Options)
 
-// ClientOptions control behavior of the client.
-type ClientOptions struct {
-	metrics   *jaeger.Metrics
+// Options control behavior of the client.
+type Options struct {
+	metrics   metrics.Factory
 	logger    jaeger.Logger
+	reporter  jaeger.Reporter
 	observers []jaeger.Observer
 }
 
-// Metrics creates a ClientOption that initializes Metrics in the client,
+// Metrics creates a Option that initializes Metrics in the client,
 // which is used to emit statistics.
-func Metrics(factory metrics.Factory) ClientOption {
-	return func(c *ClientOptions) {
-		c.metrics = jaeger.NewMetrics(factory, nil)
+func Metrics(factory metrics.Factory) Option {
+	return func(c *Options) {
+		c.metrics = factory
 	}
 }
 
 // Logger can be provided to log Reporter errors, as well as to log spans
 // if Reporter.LogSpans is set to true.
-func Logger(logger jaeger.Logger) ClientOption {
-	return func(c *ClientOptions) {
+func Logger(logger jaeger.Logger) Option {
+	return func(c *Options) {
 		c.logger = logger
 	}
 }
 
+// Reporter can be provided explicitly to override the configuration.
+// Useful for testing, e.g. by passing InMemoryReporter.
+func Reporter(reporter jaeger.Reporter) Option {
+	return func(c *Options) {
+		c.reporter = reporter
+	}
+}
+
 // Observer can be registered with the Tracer to receive notifications about new Spans.
-func Observer(observer jaeger.Observer) ClientOption {
-	return func(c *ClientOptions) {
+func Observer(observer jaeger.Observer) Option {
+	return func(c *Options) {
 		c.observers = append(c.observers, observer)
 	}
+}
+
+func applyOptions(options ...Option) Options {
+	opts := Options{}
+	for _, option := range options {
+		option(&opts)
+	}
+	if opts.metrics == nil {
+		opts.metrics = metrics.NullFactory
+	}
+	if opts.logger == nil {
+		opts.logger = jaeger.NullLogger
+	}
+	return opts
 }

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package config
+
+import (
+	"testing"
+
+	opentracing "github.com/opentracing/opentracing-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/jaeger-lib/metrics"
+
+	"github.com/uber/jaeger-client-go"
+)
+
+func TestApplyOptions(t *testing.T) {
+	metricsFactory := metrics.NewLocalFactory(0)
+	observer := fakeObserver{}
+	opts := applyOptions(
+		Metrics(metricsFactory),
+		Logger(jaeger.StdLogger),
+		Observer(observer),
+	)
+	assert.Equal(t, jaeger.StdLogger, opts.logger)
+	assert.Equal(t, metricsFactory, opts.metrics)
+	assert.Equal(t, []jaeger.Observer{observer}, opts.observers)
+}
+
+func TestApplyOptionsDefaults(t *testing.T) {
+	opts := applyOptions()
+	assert.Equal(t, jaeger.NullLogger, opts.logger)
+	assert.Equal(t, metrics.NullFactory, opts.metrics)
+}
+
+type fakeObserver struct{}
+
+func (o fakeObserver) OnStartSpan(operationName string, options opentracing.StartSpanOptions) jaeger.SpanObserver {
+	return nil
+}


### PR DESCRIPTION
Also renames config ClientOptions to Options and adds `applyOptions()` func to match Jaeger backend coding patterns.