### PR TITLE
Add overflow checker

### DIFF
--- a/utils/overflow_checker.go
+++ b/utils/overflow_checker.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package utils
+
+import (
+	"sync"
+	"time"
+)
+
+// OverflowChecker is a filter that checks if an event has occurred more than a specified number of times.
+type OverflowChecker interface {
+	CheckOverflow() bool
+}
+
+type overflowChecker struct {
+	sync.Mutex
+
+	lastTick   time.Time
+	balance    int64
+	maxBalance int64
+	duration   time.Duration
+
+	timeNow func() time.Time
+}
+
+// NewOverflowChecker creates a new overflow checker formulated in terms of a maxBalance and duration.
+// The first call to CheckOverflow() creates a new balance with a TTL of duration. Every subsequent
+// CheckOverflow() call increments the balance unless the balance has expired. If the balance expired,
+// a new balance will be initialized with a TTL of duration.
+//
+// Once the balance is greater than maxBalance, an overflow has occurred and the function will return
+// true. Otherwise it returns false. Once an overflow occurs, a new balance is initialized with a TTL
+// of duration.
+func NewOverflowChecker(maxBalance int64, duration time.Duration) OverflowChecker {
+	return &overflowChecker{
+		maxBalance: maxBalance,
+		duration:   duration,
+		lastTick:   time.Now(),
+		timeNow:    time.Now,
+	}
+}
+
+func (s *overflowChecker) CheckOverflow() bool {
+	s.Lock()
+	defer s.Unlock()
+	currentTime := s.timeNow()
+	elapsedTime := currentTime.Sub(s.lastTick)
+	if elapsedTime > s.duration {
+		// Start new balance
+		s.balance = 1
+		s.lastTick = currentTime
+		return false
+	}
+	s.balance++
+	if s.balance > s.maxBalance {
+		// Start new balance
+		s.balance = 1
+		s.lastTick = currentTime
+		return true
+	}
+	return false
+}

--- a/utils/overflow_checker_test.go
+++ b/utils/overflow_checker_test.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package utils
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverflowChecker(t *testing.T) {
+	s := NewOverflowChecker(2, time.Second)
+	// stop time
+	ts := time.Now()
+	s.(*overflowChecker).lastTick = ts
+	s.(*overflowChecker).timeNow = func() time.Time {
+		return ts
+	}
+	assert.False(t, s.CheckOverflow())
+	assert.False(t, s.CheckOverflow())
+	assert.True(t, s.CheckOverflow())
+
+	assert.False(t, s.CheckOverflow())
+	// move time 1.1s forward, the bucket should empty
+	s.(*overflowChecker).timeNow = func() time.Time {
+		return ts.Add(1100 * time.Millisecond)
+	}
+	assert.False(t, s.CheckOverflow())
+	assert.False(t, s.CheckOverflow())
+	assert.True(t, s.CheckOverflow())
+
+	assert.False(t, s.CheckOverflow())
+	// move time 200ms forward, not enough time for the bucket to empty
+	s.(*overflowChecker).timeNow = func() time.Time {
+		return ts.Add(1300 * time.Millisecond)
+	}
+	assert.True(t, s.CheckOverflow())
+}


### PR DESCRIPTION
The overflow checker will be used as part of client side short circuiting. I initially looked at util/rate_limiter.go but I couldn't get it to work as I needed it.

I'm not a big fan of the name overflow_checker and was wondering if I should make this a strategy of rate_limiter which you can plugin during initialization.