### PR TITLE
Save baggage in span

### DIFF
--- a/propagation_test.go
+++ b/propagation_test.go
@@ -104,14 +104,13 @@ func TestSpanPropagator(t *testing.T) {
 		assert.Equal(t, exp.context, sp.context, formatName)
 		assert.Equal(t, "span.kind", sp.tags[0].key)
 		assert.Equal(t, expTags, sp.tags[1:] /*skip span.kind tag*/, formatName)
-		assert.Equal(t, exp.logs, sp.logs, formatName)
+		assert.NotEqual(t, exp.logs, sp.logs, formatName) // Only the parent span should have baggage logs
 		// Override collections to avoid tripping comparison on different pointers
 		sp.context = exp.context
 		sp.tags = exp.tags
 		sp.logs = exp.logs
 		sp.operationName = op
 		sp.references = exp.references
-		sp.baggageRecords = exp.baggageRecords
 		// Compare the rest of the fields
 		assert.Equal(t, exp, sp, formatName)
 	}

--- a/propagation_test.go
+++ b/propagation_test.go
@@ -111,6 +111,7 @@ func TestSpanPropagator(t *testing.T) {
 		sp.logs = exp.logs
 		sp.operationName = op
 		sp.references = exp.references
+		sp.baggageRecords = exp.baggageRecords
 		// Compare the rest of the fields
 		assert.Equal(t, exp, sp, formatName)
 	}

--- a/span.go
+++ b/span.go
@@ -178,15 +178,14 @@ func (s *Span) SetBaggageItem(key, value string) opentracing.Span {
 	s.Lock()
 	defer s.Unlock()
 	s.context = s.context.WithBaggageItem(key, value)
-	if !s.context.IsSampled() {
-		return s
+	if s.context.IsSampled() {
+		// If sampled, record the baggage in the span
+		s.logFieldsNoLocking(
+			log.String("event", "baggage"),
+			log.String("key", key),
+			log.String("value", value),
+		)
 	}
-	// If sampled, record the baggage in the span
-	s.logFieldsNoLocking(
-		log.String("event", "baggage"),
-		log.String("key", key),
-		log.String("value", value),
-	)
 	return s
 }
 

--- a/span.go
+++ b/span.go
@@ -116,11 +116,11 @@ func (s *Span) LogFields(fields ...log.Field) {
 	if !s.context.IsSampled() {
 		return
 	}
-	s.logFieldsWithLock(fields...)
+	s.logFieldsNoLocking(fields...)
 }
 
 // this function should only be called while holding a Write lock
-func (s *Span) logFieldsWithLock(fields ...log.Field) {
+func (s *Span) logFieldsNoLocking(fields ...log.Field) {
 	lr := opentracing.LogRecord{
 		Fields:    fields,
 		Timestamp: time.Now(),
@@ -182,7 +182,7 @@ func (s *Span) SetBaggageItem(key, value string) opentracing.Span {
 		return s
 	}
 	// If sampled, record the baggage in the span
-	s.logFieldsWithLock(
+	s.logFieldsNoLocking(
 		log.String("event", "baggage"),
 		log.String("key", key),
 		log.String("value", value),

--- a/span_test.go
+++ b/span_test.go
@@ -57,7 +57,7 @@ func assertBaggageRecords(t *testing.T, sp *Span, expected map[string]string) {
 		value := logRecord.Fields[2].Value().(string)
 
 		require.Contains(t, expected, key)
-		assert.Equal(t, value, expected[key])
+		assert.Equal(t, expected[key], value)
 	}
 }
 

--- a/testutils/mock_agent_test.go
+++ b/testutils/mock_agent_test.go
@@ -50,8 +50,14 @@ func TestMockAgentSpanServer(t *testing.T) {
 
 		err = client.EmitZipkinBatch(spans)
 		assert.NoError(t, err)
-		time.Sleep(5 * time.Millisecond)
 
+		for k := 0; k < 100; k++ {
+			time.Sleep(time.Millisecond)
+			spans = mockAgent.GetZipkinSpans()
+			if len(spans) == i {
+				break
+			}
+		}
 		spans = mockAgent.GetZipkinSpans()
 		require.Equal(t, i, len(spans))
 		for j := 0; j < i; j++ {

--- a/thrift_span_test.go
+++ b/thrift_span_test.go
@@ -299,6 +299,21 @@ func TestSpecialTags(t *testing.T) {
 	assert.NotNil(t, findAnnotation(thriftSpan, "ss"))
 }
 
+func TestBaggageLogs(t *testing.T) {
+	tracer, closer := NewTracer("DOOP",
+		NewConstSampler(true),
+		NewNullReporter())
+	defer closer.Close()
+
+	sp := tracer.StartSpan("s1").(*Span)
+	sp.SetBaggageItem("auth.token", "token")
+	ext.SpanKindRPCServer.Set(sp)
+	sp.Finish()
+
+	thriftSpan := buildThriftSpan(sp)
+	assert.NotNil(t, findAnnotation(thriftSpan, `{"event":"baggage","key":"auth.token","value":"token"}`))
+}
+
 func findAnnotation(span *zipkincore.Span, name string) *zipkincore.Annotation {
 	for _, a := range span.Annotations {
 		if a.Value == name {

--- a/tracer.go
+++ b/tracer.go
@@ -286,6 +286,7 @@ func (t *tracer) newSpan() *Span {
 	sp.tracer = nil
 	sp.tags = nil
 	sp.logs = nil
+	sp.baggageRecords = nil
 	return sp
 }
 

--- a/tracer.go
+++ b/tracer.go
@@ -286,7 +286,6 @@ func (t *tracer) newSpan() *Span {
 	sp.tracer = nil
 	sp.tags = nil
 	sp.logs = nil
-	sp.baggageRecords = nil
 	return sp
 }
 


### PR DESCRIPTION
We want to save the baggage when it is first set within the span. I think it makes sense to make baggage a first class item.

The new [jaeger.thrift idl](https://github.com/uber/jaeger-idl/blob/master/thrift/jaeger.thrift) will look like:

```
struct BaggageRecord {
  1: required string key
  2: required string value
  3: optional i64 timestamp
}

struct Span {
  ...
  12: optional list<BaggageRecord> baggageRecords
}
```
Alternatives would be either tags or logs.
tag: we only have key-value so it would have to be a json blob of baggage:{key, value, timestamp}
log: same as above, we would have to use the fields which are key-value as well (json blob)

By making this a first class citizen, we don't need to manually parse the tags/logs for the UI.

Why timestamp in BaggageRecord? If the same baggage key is set multiple times, we can use the timestamp to differentiate them. (Not sure if it's really needed)
