### PR TITLE
Move queueLength to the top of the struct to guarantee 64bit alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes by Version
 2.6.1 (unreleased)
 ------------------
 
-- Nothing yet
+- Move reporter.queueLength to the top of the struct to guarantee 64bit alignment [#158](https://github.com/uber/jaeger-client-go/pull/158)
 
 
 2.6.0 (2017-03-28)

--- a/reporter.go
+++ b/reporter.go
@@ -163,10 +163,13 @@ const (
 )
 
 type remoteReporter struct {
+	// must be first in the struct because `sync/atomic` expects 64-bit alignment.
+	// Cf. https://github.com/uber/jaeger-client-go/issues/155, https://goo.gl/zW7dgq
+	queueLength int64
+
 	reporterOptions
 	sender       Transport
 	queue        chan *Span
-	queueLength  int64 // signed because metric's gauge is signed
 	queueDrained sync.WaitGroup
 	flushSignal  chan *sync.WaitGroup
 }


### PR DESCRIPTION
Fixes #155