### PR TITLE
Revert "Rename endpoint to operation for RPC metrics (#150)"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -112,7 +112,7 @@ func (c Configuration) New(
 	if c.RPCMetrics {
 		Observer(
 			rpcmetrics.NewObserver(
-				opts.metrics.Namespace("jaeger", map[string]string{"component": "jaeger"}),
+				opts.metrics.Namespace("jaeger-rpc", map[string]string{"component": "jaeger"}),
 				rpcmetrics.DefaultNameNormalizer,
 			),
 		)(&opts) // adds to c.observers

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -174,8 +174,8 @@ func TestConfigWithRPCMetrics(t *testing.T) {
 
 	testutils.AssertCounterMetrics(t, metrics,
 		testutils.ExpectedMetric{
-			Name:  "jaeger.requests",
-			Tags:  map[string]string{"component": "jaeger", "operation": "test", "error": "false"},
+			Name:  "jaeger-rpc.requests",
+			Tags:  map[string]string{"component": "jaeger", "endpoint": "test", "error": "false"},
 			Value: 1,
 		},
 	)

--- a/rpcmetrics/endpoints.go
+++ b/rpcmetrics/endpoints.go
@@ -22,8 +22,8 @@ package rpcmetrics
 
 import "sync"
 
-// normalizedOperations is a cache for operationName -> safeName mappings.
-type normalizedOperations struct {
+// normalizedEndpoints is a cache for endpointName -> safeName mappings.
+type normalizedEndpoints struct {
 	names       map[string]string
 	maxSize     int
 	defaultName string
@@ -31,8 +31,8 @@ type normalizedOperations struct {
 	mux         sync.RWMutex
 }
 
-func newNormalizedOperations(maxSize int, normalizer NameNormalizer) *normalizedOperations {
-	return &normalizedOperations{
+func newNormalizedEndpoints(maxSize int, normalizer NameNormalizer) *normalizedEndpoints {
+	return &normalizedEndpoints{
 		maxSize:    maxSize,
 		normalizer: normalizer,
 		names:      make(map[string]string, maxSize),
@@ -42,7 +42,7 @@ func newNormalizedOperations(maxSize int, normalizer NameNormalizer) *normalized
 // normalize looks up the name in the cache, if not found it uses normalizer
 // to convert the name to a safe name. If called with more than maxSize unique
 // names it returns "" for all other names beyond those already cached.
-func (n *normalizedOperations) normalize(name string) string {
+func (n *normalizedEndpoints) normalize(name string) string {
 	n.mux.RLock()
 	norm, ok := n.names[name]
 	l := len(n.names)
@@ -56,7 +56,7 @@ func (n *normalizedOperations) normalize(name string) string {
 	return n.normalizeWithLock(name)
 }
 
-func (n *normalizedOperations) normalizeWithLock(name string) string {
+func (n *normalizedEndpoints) normalizeWithLock(name string) string {
 	norm := n.normalizer.Normalize(name)
 	n.mux.Lock()
 	defer n.mux.Unlock()

--- a/rpcmetrics/endpoints_test.go
+++ b/rpcmetrics/endpoints_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNormalizedOperations(t *testing.T) {
-	n := newNormalizedOperations(1, DefaultNameNormalizer)
+func TestNormalizedEndpoints(t *testing.T) {
+	n := newNormalizedEndpoints(1, DefaultNameNormalizer)
 
 	assertLen := func(l int) {
 		n.mux.RLock()
@@ -42,8 +42,8 @@ func TestNormalizedOperations(t *testing.T) {
 	assertLen(1)
 }
 
-func TestNormalizedOperationsDoubleLocking(t *testing.T) {
-	n := newNormalizedOperations(1, DefaultNameNormalizer)
+func TestNormalizedEndpointsDoubleLocking(t *testing.T) {
+	n := newNormalizedEndpoints(1, DefaultNameNormalizer)
 	assert.Equal(t, "ab-cd", n.normalize("ab^cd"), "fill out the cache")
 	assert.Equal(t, "", n.normalizeWithLock("xys"), "cache overflow")
 }

--- a/rpcmetrics/metrics_test.go
+++ b/rpcmetrics/metrics_test.go
@@ -37,13 +37,13 @@ func tags(kv ...string) map[string]string {
 	return m
 }
 
-func operationTags(operation string, kv ...string) map[string]string {
-	return tags(append([]string{"operation", operation}, kv...)...)
+func endpointTags(endpoint string, kv ...string) map[string]string {
+	return tags(append([]string{"endpoint", endpoint}, kv...)...)
 }
 
-func TestMetricsByOperation(t *testing.T) {
+func TestMetricsByEndpoint(t *testing.T) {
 	met := metrics.NewLocalFactory(0)
-	mbe := newMetricsByOperation(met, DefaultNameNormalizer, 2)
+	mbe := newMetricsByEndpoint(met, DefaultNameNormalizer, 2)
 
 	m1 := mbe.get("abc1")
 	m2 := mbe.get("abc1")               // from cache
@@ -60,8 +60,8 @@ func TestMetricsByOperation(t *testing.T) {
 	}
 
 	testutils.AssertCounterMetrics(t, met,
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("abc1", "error", "false"), Value: 3},
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("abc3", "error", "false"), Value: 1},
-		testutils.ExpectedMetric{Name: "requests", Tags: operationTags("other", "error", "false"), Value: 2},
+		testutils.ExpectedMetric{Name: "requests", Tags: endpointTags("abc1", "error", "false"), Value: 3},
+		testutils.ExpectedMetric{Name: "requests", Tags: endpointTags("abc3", "error", "false"), Value: 1},
+		testutils.ExpectedMetric{Name: "requests", Tags: endpointTags("other", "error", "false"), Value: 2},
 	)
 }

--- a/rpcmetrics/normalizer.go
+++ b/rpcmetrics/normalizer.go
@@ -20,13 +20,13 @@
 
 package rpcmetrics
 
-// NameNormalizer is used to convert the operation names to strings
+// NameNormalizer is used to convert the endpoint names to strings
 // that can be safely used as tags in the metrics.
 type NameNormalizer interface {
 	Normalize(name string) string
 }
 
-// DefaultNameNormalizer converts operation names so that they contain only characters
+// DefaultNameNormalizer converts endpoint names so that they contain only characters
 // from the safe charset [a-zA-Z0-9-./_]. All other characters are replaced with '-'.
 var DefaultNameNormalizer = &SimpleNameNormalizer{
 	SafeSets: []SafeCharacterSet{


### PR DESCRIPTION
This reverts commit c762689dafff561d710e838bd2aef537f90294a2.

This is a breaking change and will be removed for 2.7.0