### PR TITLE
span: Add Logs method to export logs

### DIFF
--- a/span.go
+++ b/span.go
@@ -141,6 +141,11 @@ func (s *Span) LogEvent(event string) {
 	s.Log(opentracing.LogData{Event: event})
 }
 
+// Logs returns the Span logs
+func (s *Span) Logs() []opentracing.LogRecord {
+	return s.logs
+}
+
 // LogEventWithPayload implements opentracing.Span API
 func (s *Span) LogEventWithPayload(event string, payload interface{}) {
 	s.Log(opentracing.LogData{Event: event, Payload: payload})


### PR DESCRIPTION
Logs are meant to be actionable data which requires to them to be
treated differently than traces, this commit allows accessing logs
from a Reporter to be sent to a logger.