### PR TITLE
Drop `jaeger.` prefix from `jaeger.hostname` process-level tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Changes by Version
 2.7.1 (unreleased)
 ------------------
 
-- Nothing yet
+- Drop `jaeger.` prefix from `jaeger.hostname` process-level tag
 
 
 2.7.0 (2017-06-21)

--- a/constants.go
+++ b/constants.go
@@ -39,7 +39,7 @@ const (
 	JaegerBaggageHeader = "jaeger-baggage"
 
 	// TracerHostnameTagKey used to report host name of the process.
-	TracerHostnameTagKey = "jaeger.hostname"
+	TracerHostnameTagKey = "hostname"
 
 	// TracerIPTagKey used to report ip of the process.
 	TracerIPTagKey = "ip"

--- a/jaeger_thrift_span_test.go
+++ b/jaeger_thrift_span_test.go
@@ -96,9 +96,9 @@ func TestBuildJaegerProcessThrift(t *testing.T) {
 	process := BuildJaegerProcessThrift(sp)
 	assert.Equal(t, process.ServiceName, "DOOP")
 	require.Len(t, process.Tags, 3)
-	assert.NotNil(t, findJaegerTag(JaegerClientVersionTagKey, process.Tags))
-	assert.NotNil(t, findJaegerTag(TracerHostnameTagKey, process.Tags))
-	assert.NotNil(t, findJaegerTag(TracerIPTagKey, process.Tags))
+	assert.NotNil(t, findJaegerTag("jaeger.version", process.Tags))
+	assert.NotNil(t, findJaegerTag("hostname", process.Tags))
+	assert.NotNil(t, findJaegerTag("ip", process.Tags))
 }
 
 func TestBuildLogs(t *testing.T) {


### PR DESCRIPTION
It was only needed in Zipkin format to label the tag as process-level.