### PR TITLE
Release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 Changes by Version
 ==================
 
-2.8.1 (unreleased)
+2.9.0 (2017-07-29)
 ------------------
 
-- nothing yet.
+* c0a8538 - Pin thrift <= 0.10
+* feadba6 - Introduce a parallel interface ContribObserver
 
 
 2.8.0 (2017-07-05)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ Changes by Version
 2.9.0 (2017-07-29)
 ------------------
 
-* c0a8538 - Pin thrift <= 0.10
-* feadba6 - Introduce a parallel interface ContribObserver
+- Pin thrift <= 0.10 (#179)
+- Introduce a parallel interface ContribObserver (#159)
 
 
 2.8.0 (2017-07-05)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,15 +34,7 @@ pull request is most likely to be accepted if it:
 
 ## Cutting a Release
 
-1. Create a PR "Preparing for release X.Y.Z" against master branch
-    * Alter CHANGELOG.md from `<placeholder_version> (unreleased)` to `<X.Y.Z> (YYYY-MM-DD)`
-    * Update `JaegerClientVersion` in constants.go to `Go-X.Y.Z`
-2. Create a release "Release X.Y.Z" on Github
-    * Create Tag `vX.Y.Z`
-    * Copy CHANGELOG.md into the release notes
-3. Create a PR "Back to development" against master branch
-    * Add `<next_version> (unreleased)` to CHANGELOG.md
-    * Update `JaegerClientVersion` in constants.go to `Go-<next_version>dev`
+See [RELEASE.md](./RELEASE.md)
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,11 @@
+# Release Process
+
+1. Create a PR "Preparing for release X.Y.Z" against master branch
+    * Alter CHANGELOG.md from `<placeholder_version> (unreleased)` to `<X.Y.Z> (YYYY-MM-DD)`
+    * Update `JaegerClientVersion` in constants.go to `Go-X.Y.Z`
+2. Create a release "Release X.Y.Z" on Github
+    * Create Tag `vX.Y.Z`
+    * Copy CHANGELOG.md into the release notes
+3. Create a PR "Back to development" against master branch
+    * Add `<next_version> (unreleased)` to CHANGELOG.md
+    * Update `JaegerClientVersion` in constants.go to `Go-<next_version>dev`

--- a/constants.go
+++ b/constants.go
@@ -22,7 +22,7 @@ package jaeger
 
 const (
 	// JaegerClientVersion is the version of the client library reported as Span tag.
-	JaegerClientVersion = "Go-2.8.1dev"
+	JaegerClientVersion = "Go-2.9.0"
 
 	// JaegerClientVersionTagKey is the name of the tag used to report client version.
 	JaegerClientVersionTagKey = "jaeger.version"


### PR DESCRIPTION
- Pin thrift <= 0.10 (#179)
- Introduce a parallel interface ContribObserver (#159)
