### PR TITLE
Close defaultSampler field in adaptiveSampler.

### DIFF
--- a/sampler.go
+++ b/sampler.go
@@ -338,6 +338,7 @@ func (s *adaptiveSampler) Close() {
 	for _, sampler := range s.samplers {
 		sampler.Close()
 	}
+	s.defaultSampler.Close()
 }
 
 func (s *adaptiveSampler) Equal(other Sampler) bool {


### PR DESCRIPTION
I noticed this when writing C++ implementation. `adaptiveSampler` seems to skip closing its `defaultSampler`. For the current code, it doesn't matter, since all `Close` functions/methods are left unimplemented. But thought I'd submit this anyway.