### PR TITLE
Do not coerce baggage keys to lower case

### DIFF
--- a/span.go
+++ b/span.go
@@ -21,7 +21,6 @@
 package jaeger
 
 import (
-	"strings"
 	"sync"
 	"time"
 
@@ -167,7 +166,6 @@ func (s *Span) appendLog(lr opentracing.LogRecord) {
 
 // SetBaggageItem implements SetBaggageItem() of opentracing.SpanContext
 func (s *Span) SetBaggageItem(key, value string) opentracing.Span {
-	key = normalizeBaggageKey(key)
 	s.Lock()
 	defer s.Unlock()
 	s.tracer.setBaggage(s, key, value)
@@ -176,7 +174,6 @@ func (s *Span) SetBaggageItem(key, value string) opentracing.Span {
 
 // BaggageItem implements BaggageItem() of opentracing.SpanContext
 func (s *Span) BaggageItem(key string) string {
-	key = normalizeBaggageKey(key)
 	s.RLock()
 	defer s.RUnlock()
 	return s.context.baggage[key]
@@ -248,11 +245,4 @@ func setSamplingPriority(s *Span, value interface{}) bool {
 		return true
 	}
 	return false
-}
-
-// Converts end-user baggage key into internal representation.
-// Used for both read and write access to baggage items.
-func normalizeBaggageKey(key string) string {
-	// TODO(yurishkuro) normalizeBaggageKey: cache the results in some bounded LRU cache
-	return strings.Replace(strings.ToLower(key), "_", "-", -1)
 }

--- a/span_test.go
+++ b/span_test.go
@@ -36,7 +36,7 @@ func TestBaggageIterator(t *testing.T) {
 	sp1 := tracer.StartSpan("s1").(*Span)
 	sp1.SetBaggageItem("Some_Key", "12345")
 	sp1.SetBaggageItem("Some-other-key", "42")
-	expectedBaggage := map[string]string{"some-key": "12345", "some-other-key": "42"}
+	expectedBaggage := map[string]string{"Some_Key": "12345", "Some-other-key": "42"}
 	assertBaggage(t, sp1, expectedBaggage)
 	assertBaggageRecords(t, sp1, expectedBaggage)
 


### PR DESCRIPTION
It is not done in the clients in other languages, and is not necessary until the keys go into http headers. At the moment we already convert to lower case when extracting the keys from text map
```
key := strings.ToLower(rawKey) // TODO not necessary for plain TextMap
```